### PR TITLE
add original fine-tuning code (+data)

### DIFF
--- a/original_finetuning_for_intents/data_einsatzbefehl/dev.tsv
+++ b/original_finetuning_for_intents/data_einsatzbefehl/dev.tsv
@@ -1,0 +1,283 @@
+UAV	UAV hat Softwareprobleme wir versuchen es zu beheben	Information_geben
+TL	Ja verstanden	Information_geben
+TL	Bitte melden wenn wieder einsatzbereit	Einsatzbefehl
+UAV	Verstanden	Zusage
+TL	UGV-1 für Einsatzleiter	Kontakt_Anfrage
+UGV-1	Hier UGV-1	Kontakt_Bestaetigung
+TL	Wie ist der Status?	Information_nachfragen
+UGV-1	Ja ich hab mich hier erst weiter nach vorne bewegt	Information_geben
+UGV-1	Weiter keine Feststellung rechts ist der Feuerlöscher	Information_geben
+UGV-1	Auf der linken Seite sehe ich eine Palette mit Wellen	Information_geben
+UGV-1	Werde weiter geradeaus erkunden kommen	Information_geben
+UGV-1	Ja war schon weiter	Information_geben
+UAV	UAV ist wieder einsatzbereit	Information_geben
+TL	Ja verstanden	Information_geben
+TL	Dann bitte erneut starten und dann in östlicher Richtung erst mal fliegen	Einsatzbefehl
+TL	Dass du dass du mal ein Foto machst du auf Höhe von ASA 310	Einsatzbefehl
+TL	Ich orientiere mich nur an der Karte das heißt nach rechts wäre Osten du folgst einfach der langen Straße praktisch	Information_geben
+UAV	Alles klar	Zusage
+UAV	danke	Sonstiges
+UGV-2	Teamleiter von UGV-2	Kontakt_Anfrage
+TL	Höre	Kontakt_Bestaetigung
+UGV-2	Ich hab dir gerade ein Bild geschickt	Information_geben
+UGV-2	Da steht ein Stuhl auf dem Stuhl liegt ein Paket und vor dem Stuhl steht ein Paket	Information_geben
+UGV-2	Sicht ist relativ schlecht	Information_geben
+UGV-2	das blendet stark	Information_geben
+TL	Ist das schlimm?	Information_nachfragen
+TL	Ja ist verstanden	Information_geben
+TL	Ich habe gerade keine Connection	Information_geben
+TL	kann dein Foto nicht sehen	Information_geben
+TL	Bleib mal gerade an der Position	Einsatzbefehl
+TL	wir starten dich noch gerade neu	Information_geben
+TL	UGV-2 von Einsatzleiter	Kontakt_Anfrage
+UGV-2	UGV-2	Kontakt_Bestaetigung
+TL	Also ich kann das eine nicht gut erkennen	Information_geben
+TL	Dein Einsatzauftrag trotzdem setz den Arm ein und nimm die Probe auf	Einsatzbefehl
+UAV	UAV hat Bilder in westlicher Blickrichtung verfügbar	Information_geben
+TL	Ja ist verstanden	Information_geben
+UGV-1	Teamleader von UGV-1 kommen	Kontakt_Anfrage
+TL	Kommen	Kontakt_Bestaetigung
+UGV-1	Ja ich hab dir jetzt mal ein Foto von meinem Standort geschickt	Information_geben
+UGV-1	Sehe den Tango rechtseitig vor mir	Information_geben
+UGV-1	Würd jetzt weiter geradeaus fahren und da weiter erkunden	Information_geben
+TL	Moment warten	Sonstiges
+TL	UGV-1	Kontakt_Anfrage
+UGV-1	Hier UGV-1	Kontakt_Bestaetigung
+TL	Wo laufen denn deine Fotos gerade rein in welchen dieser Container?	Information_nachfragen
+TL	Ja ich hab sie gefunden sie sind in Sankt Augustin	Information_geben
+UGV-1	Ja ich erkunde dann weiter geradeaus kommen	Information_geben
+TL	Negativ	Absage
+TL	Nähere dich mal UGV-2	Einsatzbefehl
+TL	da sind zwei Proben die er eventuell aufnehmen muss	Information_geben
+TL	Fahr mal bitte näher daran	Einsatzbefehl
+TL	und mach mal Foto wie er das macht	Einsatzbefehl
+TL	Und guck mal ob du ein genaues Bild von diesen Samples kriegen kannst	Einsatzbefehl
+UGV-1	Ja ich gehe jetzt vor zu UGV-2	Zusage
+UGV-1	und versuch die Probenentnahme zu fotografieren kommen	Zusage
+TL	UAV für Einsatzleiter	Kontakt_Anfrage
+TL	Wo ist gerade dein Standort?	Information_nachfragen
+UAV	Ungefähr an der Position von ASA 310	Information_geben
+TL	Okay	Information_geben
+TL	Hast du das letzte Foto gepublished?	Information_nachfragen
+TL	Ich konnte es noch nicht sehen	Information_geben
+UAV	Der UAV Pilot berichtet von Rauch der aus der Halle kommt	Information_geben
+UAV	Wir versuchen davon ein Foto zu machen	Information_geben
+TL	Ja verstanden	Zusage
+UGV-1	Teamleader von UGV-1 kommen	Kontakt_Anfrage
+TL	Höre	Kontakt_Bestaetigung
+UGV-1	Ich seh ein extrem helles hell beleuchtetes Gerät	Information_geben
+UGV-1	Ich kann's nicht erkennen was es ist	Information_geben
+TL	Ja was willst du mir damit sagen?	Information_nachfragen
+UGV-1	Ja schau mal auf das Foto	Information_geben
+	bin ich in der Nähe des UGV-2? Frage	Information_nachfragen
+TL	Foto 235?	Information_nachfragen
+UGV-1	Kann ich dir nicht genau sagen	Information_geben
+UGV-1	Kann ich nicht bestätigen	Information_geben
+TL	UAV für Einsatzleitung	Kontakt_Anfrage
+UAV	UAV hört	Kontakt_Bestaetigung
+TL	Also ich kann keine Rauchentwicklung auf deinem Foto erkennen	Information_geben
+TL	Kreise mal bitte jetzt dann um ASA 352 herum	Einsatzbefehl
+TL	Und mach sozusagen mal ein Rundumfoto das heißt aus den anderen beiden Himmelsrichtungen auch noch	Einsatzbefehl
+UAV	Das kann ich hier leider nicht erkennen	Absage
+UAV	Das letzte Foto das ich geshared habe?	Information_nachfragen
+TL	Okay das scheint 297 zu sein	Information_geben
+UGV-1	Teamleader von UGV-1 kommen	Kontakt_Anfrage
+TL	Höre	Kontakt_Bestaetigung
+UGV-1	Ja im letzten Foto das ich geteilt habe ich versucht die Probenentnahme zu fotografieren kommen	Information_geben
+TL	Ja	Information_geben
+TL	Ja ich guck's mir an	Information_geben
+TL	UAV für Einsatzleitung kommen	Kontakt_Anfrage
+UAV	UAV hört	Kontakt_Bestaetigung
+TL	Wo ist dieser eine Eingang jetzt genau ist der praktisch südlich von ASA 310?	Information_nachfragen
+UAV	Das ist südlich das ist es an der an der Position wo Echo-Start wo der Echo-Punkt ist also der der Halleneingang hier	Information_geben
+TL	O. k.	Information_geben
+UGV-1	Teamleader von UGV-1 kommen	Kontakt_Anfrage
+TL	UGV-1 kommen Sie	Kontakt_Bestaetigung
+UGV-1	Ja ich versuch die Probeentnahmen zu fotografieren	Information_geben
+UGV-1	Habe aber hier extrem schlechte Sicht	Information_geben
+UGV-1	aufgrund von reflektierendem Licht	Information_geben
+UGV-1	kommen	Kontakt_Anfrage
+TL	Ja verstanden	Information_geben
+TL	UGV-1 von Einsatzleitung	Kontakt_Anfrage
+UGV-1	UGV-1 hört	Kontakt_Bestaetigung
+TL	Ja die UAV hat berichtet dass es eine Rauchentwicklung gibt aus dem Hallentorbogen wo unser Startpunkt ist	Information_geben
+TL	Kannst du dich in die Richtung zurückbegeben und da mal nachgucken	Einsatzbefehl
+UGV-1	Ja ich versuch zum Startpunkt zurückzukehren und prüfe ob Rauchentwicklung	Zusage
+TL	Wenn's geht fährst du nicht den Weg zurück den du gekommen bist sondern eben erst mal Richtung Süden von Darmstadt aus und dann wieder Richtung Richtung Startpunkt sozusagen	Einsatzbefehl
+UGV-1	Ja ich prüf das ob ich da weiterkomme kommen	Zusage
+UGV-2	Teamleiter von UGV-2	Kontakt_Anfrage
+TL	Höre	Kontakt_Bestaetigung
+UGV-2	Die erste Probe genommen und in den Korb abgelegt	Information_geben
+UGV-2	versuche jetzt die zweite auf dem Stuhl zu nehmen	Information_geben
+TL	Ja verstanden	Zusage
+TL	Konntest du schon mal was erkennen sind die Behälter dicht oder undicht?	Information_nachfragen
+UGV-2	Das ist nicht erkennbar	Information_geben
+UGV-2	es handelt sich scheinbar um Papp-Pakete kleine	Information_geben
+TL	Und konntest du irgendwelche Markierungen darauf erkennen oder Schilder?	Information_nachfragen
+UGV-2	Ich versuch gleich nach dem Ablegen vom zweiten nochmal nen Blick auf den anderen zu werfen	Information_geben
+UGV-1	Ja hab mich jetzt nach Süden gewandt sehe jetzt in erster Linie keine Möglichkeit auf dem anderem Wege zurückzukommen	Information_geben
+UGV-1	Könnte linksseitig schauen ob ich nen Blick auf die auf die andere Seite bekommen kann	Information_geben
+UGV-1	aber der Weg wird wahrscheinlich nicht zur Verfügung stehen	Information_geben
+UGV-1	kommen	Kontakt_Anfrage
+TL	Fahr trotzdem erst mal in die Richtung	Einsatzbefehl
+UGV-2	Teamleiter von UGV-2	Kontakt_Anfrage
+TL	Höre	Kontakt_Bestaetigung
+UGV-2	Auf dem Stuhl befinden sich zwei Pakete	Information_geben
+UGV-2	Eins davon ist mit dem Gefahrgutssymbol reizend das X gekennzeichnet Trader Oxyn Nummer eins	Information_geben
+TL	Kannst du ein Foto machen?	Einsatzbefehl
+UGV-2	Kann ich ein Snapshot von der linken Seite machen weißt du das?	Information_nachfragen
+UAV	Teamleiter von UAV	Kontakt_Anfrage
+TL	Höre	Kontakt_Bestaetigung
+UAV	Ich habe ein Übersicht ein Übersichtsfoto geshared von ungefähr der Position Tango ASA 352	Information_geben
+UAV	Und jetzt sind wir gelandet um den Akku zu tauschen	Information_geben
+UAV	Erbitte weitere Anweisungen	Information_nachfragen
+TL	Ja	Information_geben
+TL	der Einsatzleiter an alle	Kontakt_Anfrage
+TL	Wenn ihr Fotos macht bitte gebt mir die Fotonummer	Einsatzbefehl
+TL	ich verlier gerade jetzt ein bisschen den Überblick über die Fotos	Information_geben
+UGV-1	Teamleiter von UGV-1 kommen	Kontakt_Anfrage
+TL	Höre	Kontakt_Bestaetigung
+UGV-1	Ja ich könnte jene Rauchentwicklung feststellen beziehungsweise es könnte eine Rauchentwicklung sein	Information_geben
+UGV-1	Aber kann da nicht näher erkunden da da ein Geländer im Weg ist	Information_geben
+	kommen	Kontakt_Anfrage
+UGV-1	Ich hab dir ein Foto gemacht	Information_geben
+UGV-1	Ich meine müsste Foto 300 sein	Information_geben
+UGV-1	kommen	Kontakt_Anfrage
+TL	Ja verstanden	Information_geben
+UGV-1	Teamleader von UGV-1 kommen	Kontakt_Anfrage
+UGV-1	Ich hab die Connection zur Database verloren	Information_geben
+TL	Ja okay	Information_geben
+TL	dann machen wir mal gerade einen Neustart	Information_geben
+UAV	Teamleiter von UAV	Kontakt_Anfrage
+TL	Höre	Kontakt_Bestaetigung
+UAV	UAV ist wieder startbereit	Information_geben
+UGV-1	Teamleader von UGV-1	Kontakt_Anfrage
+TL	UAV dann bitte starten Live-Monitoring	Einsatzbefehl
+TL	guck mal ob du da weitere Rauchentwicklungen finden kannst	Einsatzbefehl
+TL	UGV-1	Kontakt_Bestaetigung
+UGV-1	Ja ich hab hier keine Reaktion bei dem Roboter und keine Verbindung mehr zur Datenbank	Information_geben
+UGV-1	kommen	Kontakt_Anfrage
+TL	UGV-2 für Einsatzleiter	Kontakt_Anfrage
+UGV-2	UGV-2	Kontakt_Bestaetigung
+TL	Gibt's ein technisches Problem bei dir?	Information_nachfragen
+UGV-2	Ja ich versuchte ihn gerade in den Behälter zu setzen aber irgendwie hat er sich aufgehangen	Information_geben
+TL	Ja verstanden	Information_geben
+TL	Das heißt du kannst im Moment gar nichts machen?	Information_nachfragen
+UGV-2	Also ich hab gerade die Rückmeldung gekriegt dass bei UGV-2 das Kamerakabel zu oft oben drumgewickelt ist	Information_geben
+UGV-2	und dass deshalb der Arm nicht mehr geht	Information_geben
+TL	Okay	Information_geben
+TL	konntest du denn eine Probenahme beenden?	Information_nachfragen
+UGV-2	Die erste Probenahme ist beendet das zweite Paket hängt in der Place pose über der Box	Information_geben
+TL	Gut	Information_geben
+TL	das heißt du kannst dich jetzt ja gar nicht bewegen?	Information_nachfragen
+UGV-2	Das könnte man ausprobieren ob man sich bewegen kann aber ich denke eher nicht	Information_geben
+TL	Halt deine Position	Einsatzbefehl
+UAV	Teamleader von UAV	Kontakt_Anfrage
+TL	Höre	Kontakt_Bestaetigung
+UAV	Wir haben weitere Fotos von der Rauchentwickung direkt an der Startposition am Eingang	Information_geben
+UAV	Leider kann ich nicht sehen welches die Fotonummern sind	Information_geben
+UAV	Kann ich versuchen	Information_geben
+UAV	Wir haben da wahrscheinlich dann Probleme mit der Datenverbindung	Information_geben
+UAV	Aber wir werden's mal versuchen	Information_geben
+TL	Ja verstanden	Zusage
+TL	UGV-1 für Einsatzleiter	Kontakt_Anfrage
+TL	UGV UGV-1	Kontakt_Anfrage
+UGV-1	UGV-1	Kontakt_Bestaetigung
+TL	Wie ist jetzt dein Status	Information_nachfragen
+UGV-1	Eher Status 6	Information_geben
+UGV-1	kommen	Kontakt_Anfrage
+TL	Okay	Information_geben
+TL	d.h. wir haben beide UGV im Moment nicht einsatzbereit?	Information_nachfragen
+UGV-1	Richtig verstanden	Zusage
+UAV	UAV landet	Information_geben
+TL	Ja verstanden	Information_geben
+TL	dann für euch Ende der Mission	Einsatzbefehl
+TL	UGV-2 für Einsatzleiter	Kontakt_Anfrage
+UGV-2	UGV-2 hört	Kontakt_Bestaetigung
+TL	Ja dann versuch vorsichtig zurückzukommen	Einsatzbefehl
+UGV-2	Ja dann versuche ich mal vorsichtig zurückzukommen	Zusage
+UGV-1	Teamleader von UGV-1	Kontakt_Anfrage
+TL	Höre	Kontakt_Bestaetigung
+UGV-1	Ja my robot is lost	Information_geben
+TL	Ja	Information_geben
+TL	dann Missionsende für Sie	Einsatzbefehl
+TL	Andreas Andreas von Markus kommen	Kontakt_Anfrage
+UGV-1	ja Andreas kommen	Kontakt_Bestaetigung
+TL	Bodenroboter zwei von Markus kommen	Kontakt_Anfrage
+TL	Feuerwehr Bochum von Markus kommen	Kontakt_Anfrage
+UGV-1	Markus von Andreas kommen	Kontakt_Anfrage
+TL	Andreas kommen	Kontakt_Bestaetigung
+UGV-1	ich wäre soweit einsatzbereit	Information_geben
+UGV-1	soll ich meinen Erkundungsbefehl fortsetzen oder beginnen?	Information_nachfragen
+TL	ja umgehend beginnen ohne möglichst wenig Zeitverzögerung um eine höhere Erfolgschance zur Menschenrettung zu haben	Information_geben
+UGV-1	ja verstanden ich beginne mit der Erkundung	Information_geben
+TL	Andreas von Markus kommen	Kontakt_Anfrage
+UGV-1	ja Andreas kommen	Kontakt_Bestaetigung
+TL	gibt es schon irgendwelche nennenswerten Erkenntnisse?	Information_nachfragen
+UGV-1	negativ keine nennenswerten Erkenntnisse	Absage
+TL	ja verstanden	Information_geben
+TL	Andreas von Markus kommen	Kontakt_Anfrage
+UGV-1	ja Andreas kommen	Kontakt_Bestaetigung
+TL	hat er schon irgendwelche nenneswerten Erkenntnisse mit Hinblick auf besondere Gefahren oder thermische Ausbreitung?	Information_nachfragen
+UGV-1	nein negativ	Absage
+TL	ja das ist gut zu wissen verstanden	Information_geben
+TL	Andreas und Daniel könnt ihr mir beide jeweils schon mal ein Foto von eurem aktuellen Standort senden?	Einsatzbefehl
+UGV-1	meine Kamera die Realbild-Kamera ist ausgefallen	Absage
+UGV-1	ich kann dir lediglich ein Wärmebild schicken	Information_geben
+TL	das ist eigentlich nicht notwendig	Absage
+UGV-1	okay	Information_geben
+UGV-1	sobald ich eine Veränderung habe schicke ich dir ein Bild	Information_geben
+TL	verstanden	Zusage
+UAV	Markus für Dirk	Kontakt_Anfrage
+TL	Dirk kommen	Kontakt_Bestaetigung
+UAV	die Drohne wird startbereit gemacht	Information_geben
+UAV	wir werden gleich mit der Personensuche starten	Information_geben
+TL	ja	Information_geben
+TL	den Suchbeginn bitte mitteilen	Einsatzbefehl
+TL	der Einsatz-Auftrag ist unverändert Erkundung nach Personen	Information_geben
+UGV-1	verstanden	Information_geben
+UAV	Markus für Dirk	Kontakt_Anfrage
+TL	Dirk kommen	Kontakt_Bestaetigung
+UAV	die Drohne startet jetzt	Information_geben
+TL	hier Markus verstanden	Information_geben
+TL	Andreas von Markus kommen	Kontakt_Anfrage
+UGV-1	hier Andreas kommen	Kontakt_Bestaetigung
+TL	gibt es irgendwelche Erkenntnisse zur Personensuche?	Information_nachfragen
+UGV-1	bis dato noch nicht	Absage
+UGV-1	ich bin jetzt einen Weg bis zum Ende weitergefahren und dann gehe ich linker Handregel weiter	Information_geben
+TL	ja verstanden	Information_geben
+TL	Daniel von Markus kommen	Kontakt_Anfrage
+UGV-2	Daniel hört	Kontakt_Bestaetigung
+TL	gibt es schon irgendwelche Erkenntnisse über das Ausmaß das Schadenausmaß und Gefahren?	Information_nachfragen
+UGV-2	nein negativ	Absage
+UGV-2	befinde mich noch in der Startposition	Information_geben
+TL	das ist verstanden	Information_geben
+TL	Dirk von Markus kommen	Kontakt_Anfrage
+UAV	hier ist Dirk	Kontakt_Bestaetigung
+UAV	nein ich habe zur Zeit überhaupt kein Bild von der Drohne	Information_geben
+TL	das ist verstanden	Information_geben
+UGV-1	Markus von Andreas kommen	Kontakt_Anfrage
+TL	Andreas kommen	Kontakt_Bestaetigung
+UGV-1	ich bin eine Etage hochgefahren als den Startgang ganz durch dann links ein Stockwerk gewechselt	Information_geben
+UGV-1	ich habe hier extreme Rauchentwicklung	Information_geben
+TL	ja das ist verstanden	Information_geben
+UGV-1	aber aktuell noch keine Hitze-Direktion	Information_geben
+TL	ist bis dahin gefahrlosen Einsatz von Einsatzkräften möglich?	Information_nachfragen
+UGV-1	meine Einschätzung unter PA jederzeit möglich ja	Zusage
+TL	das ist verstanden	Information_geben
+UGV-1	Markus von Andreas kommen	Kontakt_Anfrage
+TL	hier Markus kommen	Kontakt_Bestaetigung
+UGV-1	im ersten Obergeschoss wo ich mich gerade aufhalte müsste auch der Brandherd sein	Information_geben
+UGV-1	ich habe hier jetzt gerade eine Hitzequelle ausgemacht definitiv keine Person	Information_geben
+TL	hier Markus verstanden	Information_geben
+UGV-2	Andreas von Daniel	Kontakt_Anfrage
+UGV-1	hier Andreas kommen	Kontakt_Bestaetigung
+UGV-2	Markus von Daniel	Kontakt_Anfrage
+TL	hier Markus	Kontakt_Bestaetigung
+UGV-2	Roboter hat zwei komplette Aussetzer funktionert dann gar nicht	Information_geben
+TL	Daniel ich hab dich verstanden	Information_geben
+TL	hier Markus an alle Roboter	Kontakt_Anfrage
+TL	baldmöglich erstes Bildmaterial senden	Einsatzbefehl
+TL	einmal eine Rundumsicht	Einsatzbefehl
+TL	vier Bilder 360-Grad-Abdeckung	Einsatzbefehl
+UGV-1	Andreas verstanden	Zusage

--- a/original_finetuning_for_intents/data_einsatzbefehl/test.tsv
+++ b/original_finetuning_for_intents/data_einsatzbefehl/test.tsv
@@ -1,0 +1,283 @@
+UGV-1	Markus von Andreas kommen	Kontakt_Anfrage
+TL	Andreas kommen	Kontakt_Bestaetigung
+UGV-1	habe im ersten OG gerade in der Brandentwicklung ein Gefahrgut-Fass grün mit der Kennzeichnung umweltgefährdender Stoff entdeckt	Information_geben
+TL	kannst du sehen ob irgendwelches Medium ausläuft?	Information_nachfragen
+UGV-1	es handelt sich um ein 200-Liter-Fass	Information_geben
+UGV-1	ob ein Medium ausläuft kann ich dir aktuell nicht sagen	Information_geben
+TL	Aussetzung von Thermik?	Information_nachfragen
+UGV-1	keine Thermik	Absage
+TL	okay	Information_geben
+TL	vorrängig weiter Personen suchen	Einsatzbefehl
+UGV-1	ja ich setze Personensuche fort	Zusage
+UAV	Markus für Dirk	Kontakt_Anfrage
+TL	Dirk kommen	Kontakt_Bestaetigung
+UAV	die Drohne fliegt	Information_geben
+UAV	ich habe ein Objekt von dem Rauch austritt	Information_geben
+UAV	ich schick das Foto	Information_geben
+TL	das ist gut	Zusage
+TL	einmal aus der Ferne und einmal aus der Nähe wenn möglich	Einsatzbefehl
+UGV-1	Markus von Andreas kommen	Kontakt_Anfrage
+TL	Andreas kommen	Kontakt_Bestaetigung
+UGV-1	eine Person liegend am Boden gefunden erstes OG bei der Brandentwicklung	Information_geben
+UGV-1	rechtsseitig vom Hochofen das Ding mit den Löchern	Information_geben
+UGV-1	ich schicke dir gleich ein Foto	Information_geben
+TL	nochmal wiederholen Andreas	Einsatzbefehl
+UGV-1	eine Person am Boden liegend gefunden	Information_geben
+UGV-1	erstes Geschoss bei der Brandentwicklung	Information_geben
+UGV-1	ich schicke dir gleich Fotos	Information_geben
+TL	verstanden	Information_geben
+TL	wie weit ist das von dem Treppenabsatz denn entfernt?	Information_nachfragen
+UGV-1	gefühlte 10 bis 20 meter	Information_geben
+TL	Treppenabsatz ersten OG nach 10 bis 20 metern linker Seite erste Person korrekt?	Information_nachfragen
+UGV-1	den Flur geradeaus durch links die Treppe rauf danach rechts abbiegen dann am Hochofen den Hochofen folgen	Information_geben
+UGV-1	dann finden sie die Person	Information_geben
+TL	hier Markus verstanden	Information_geben
+UGV-1	Bild kommt gleich	Information_geben
+UAV	Markus für Dirk	Kontakt_Anfrage
+TL	Dirk kommen	Kontakt_Bestaetigung
+UAV	Funkübertragung zur Zeit nicht möglich	Information_geben
+UAV	die Drohne ist gelandet wir reparieren	Information_geben
+TL	hier Markus verstanden	Information_geben
+UGV-1	Markus von Andreas kommen	Kontakt_Anfrage
+TL	Andreas kommen	Kontakt_Bestaetigung
+UGV-1	ich setze Personensuche fort	Information_geben
+TL	ja verstanden	Information_geben
+TL	sollen also zwei bis drei Vermisste sein nach den ersten Aussagen	Information_geben
+UGV-1	ja verstanden zwei bis drei Vermisste	Information_geben
+TL	Andreas von Markus kommen	Kontakt_Anfrage
+UGV-1	Hier Andreas kommen	Kontakt_Bestaetigung
+TL	sind wir da gleich dass wir jetzt zwei Personen gefunden haben oder Bilder von zwei unterschiedlichen Personen haben?	Information_nachfragen
+UGV-1	nein	Absage
+UGV-1	ich habe dir einmal ein Thermo-Image der Person geschickt und einmal ein Live-Bild der Person	Information_geben
+TL	ja	Information_geben
+TL	also es handelt sich um eine Person richtig?	Information_nachfragen
+UGV-1	das ist richtig ich habe eine Person gefunden	Zusage
+UGV-1	das Thermo-Image war eher danach hab ich ein Wechsel vorgenommen um dir ein Live-Bild zu schicken	Information_geben
+TL	das ist verstanden	Information_geben
+UAV	Markus für Dirk	Kontakt_Anfrage
+TL	Dirk kommen	Kontakt_Bestaetigung
+UAV	die Drohne ist wieder in der Luft	Information_geben
+UAV	ich habe ein Infrarotbild geschickt da sind zwei Personen zu sehen jetzt nähert sich dort eine dritte	Information_geben
+TL	hier Markus verstanden	Information_geben
+TL	also gehfähige Personen im Gefahrenbereich?	Information_nachfragen
+UAV	ja zumindest in der Nähe davon direkt neben dem Hochofen	Zusage
+TL	hier Markus verstanden	Information_geben
+TL	Dirk von Markus kommen	Kontakt_Anfrage
+UAV	Dirk hört	Kontakt_Bestaetigung
+TL	hast du Erkenntnis über zwei gehfähige Personen anhand dieses Bildes was ich auch erhalten habe?	Information_nachfragen
+UAV	das ist korrekt	Zusage
+TL	Andreas mitgehört?	Information_nachfragen
+UGV-1	ja Andreas mitgehört zwei Personen in der Nähe des Hochofens	Zusage
+TL	also haben wir insgesamt vier Personen im Gefahrenbereich?	Information_nachfragen
+UAV	Markus für Dirk	Kontakt_Anfrage
+TL	Dirk kommen	Kontakt_Bestaetigung
+UAV	es handelt sich um drei Personen die nebeneinander stehen	Information_geben
+TL	drei gehfähige Personen richtig?	Information_nachfragen
+UAV	ja	Zusage
+UAV	das Bild hab ich dir zugesandt	Information_geben
+TL	hier Markus verstanden	Information_geben
+TL	Andreas mitgehört?	Information_nachfragen
+UGV-1	ja Andreas mitgehört drei gehfähige Personen	Zusage
+TL	wir haben drei gehfähige und eine am Boden liegende Person	Information_geben
+UGV-1	Markus von Andreas	Kontakt_Anfrage
+TL	Andreas kommen	Kontakt_Bestaetigung
+UGV-1	Frage sind diese Personen alle bei der liegenden Person?	Information_nachfragen
+TL	die drei gehfähigen sind nah beieinander	Information_geben
+UGV-1	ja verstanden	Information_geben
+UAV	Markus für Dirk	Kontakt_Anfrage
+UAV	Markus für Dirk kommen	Kontakt_Anfrage
+TL	Dirk kommen	Kontakt_Bestaetigung
+UAV	so wie ich das gerade gesehen hatte war da noch ein Kopf zu sehen	Information_geben
+UAV	also es passt gut dass das drei gehfähige Personen an einer liegenden sind	Information_geben
+TL	hier Markus verstanden	Information_geben
+TL	wir machen jetzt mal einen Schnitt in der Zeit mache ich eine Übergabe	Information_geben
+UGV-1	Markus von Andreas kommen	Kontakt_Anfrage
+TL	hier Markus kommen	Kontakt_Bestaetigung
+UGV-1	Frage die drei gehfähigen Personen wurden aus der Luft erkannt ist das richtig?	Information_nachfragen
+TL	das ist korrekt	Zusage
+UGV-1	ja verstanden	Information_geben
+TL	hier Markus an alle Operator	Kontakt_Anfrage
+TL	zwei Minuten Funkstille zwecks Übergabe	Information_geben
+UGV-1	Andreas verstanden	Information_geben
+UGV-2	Daniel verstanden	Information_geben
+TL	Daniel von Markus kommen	Kontakt_Anfrage
+UGV-2	Daniel hört	Kontakt_Bestaetigung
+TL	warten	Sonstiges
+TL	Andreas von Markus kommen	Kontakt_Anfrage
+UGV-1	hier Andreas kommen	Kontakt_Bestaetigung
+TL	warten	Sonstiges
+TL	Dirk von Markus kommen	Kontakt_Anfrage
+UAV	hier ist Dirk	Kontakt_Bestaetigung
+TL	hier Markus an alle Operator	Kontakt_Anfrage
+TL	Wechsel des Leaders	Information_geben
+UAV	Dirk hat verstanden	Information_geben
+UGV-1	Andreas hat verstanden	Information_geben
+UGV-2	Daniel hat verstanden	Information_geben
+UAV	Thorsten für Dirk kommen	Kontakt_Anfrage
+TL	Thorsten hört Dirk kommt	Kontakt_Bestaetigung
+UAV	ich hab zwei Bilder gerade geschickt das eine mit vier Personen die alle gehfähig sind	Information_geben
+UAV	dann ein weiteres Bild einer Person oberhalb von den anderen erkenntlich an der Warnweste	Information_geben
+TL	also ich wiederhole wir haben vier Personen die sind gehfähig und eine weitere Person mit Warnweste auch gehfähig	Information_geben
+TL	wir haben keine am Boden liegend befindliche Person ist das korrekt?	Information_nachfragen
+UAV	das ist korrekt	Zusage
+TL	gut	Information_geben
+TL	wie verhalten sich die vier Personen verlassen sie das Gebäude und wenn ja in welche Richtung?	Information_nachfragen
+UGV-1	Thorsten von Andreas kommen	Kontakt_Anfrage
+TL	Thorsten hört Andreas kommt	Kontakt_Bestaetigung
+UGV-1	ich habe dir ebenfalls Bilder von drei Personen die aufeinander stehen rübergeschickt	Information_geben
+TL	ich hoffe ihr habt auch eine Landmarke gesetzt	Information_nachfragen
+UGV-1	der weitere der steht war die Person die vorhin gelegen hat optischen Augenscheins nach	Information_geben
+TL	ja ich werte gerade die Bilder aus kommen	Information_geben
+UGV-1	ja verstanden	Information_geben
+UAV	Thorsten für Dirk	Kontakt_Anfrage
+TL	Thorsten hört kommen	Kontakt_Bestaetigung
+UAV	die Situation von gerade kann ich jetzt nicht mehr gut einsehen weil die Rauchwolke genau davor ist	Information_geben
+UAV	ich erkunde das Umfeld weiter	Information_geben
+TL	ja such mal noch weiter	Information_geben
+TL	Hinweis an alle die vermisste Person ist noch nicht gefunden kommen	Information_geben
+UAV	Thorsten für Dirk	Kontakt_Anfrage
+TL	Thorsten hört kommen	Kontakt_Bestaetigung
+UAV	die Drohne landet wir müssen Akku tauschen	Information_geben
+UAV	und das Bild hängt	Information_geben
+TL	ja verstanden	Information_geben
+TL	Roboter 1 und Roboter 2 ich habe hier zwei Fotos, auf einem Foto ist ein Wärmebild da kann sich eine am Boden liegende Person befinden	Information_geben
+TL	wer hat dieses Foto gemacht kommen	Information_nachfragen
+UGV-1	das war Roboter 1	Information_geben
+TL	Roboter 1 können Sie den Standort nochmal anfahren	Einsatzbefehl
+TL	und von dort geradeaus weiter auf die Person zufahren?	Einsatzbefehl
+UGV-1	ja ich kann den Standort direkt nochmal anfahren	Zusage
+UGV-1	nur die Person steht jetzt	Information_geben
+TL	gehe davon aus das ist trotzdem die liegende Person ist die wir suchen und finden sollten	Information_geben
+UGV-1	das ist auch meine Vermutung	Information_geben
+UGV-1	habe Standort nochmal angefahren	Information_geben
+UGV-1	Foto ist versandt	Information_geben
+TL	verstanden	Information_geben
+UGV-1	soll ich an diesen Standort stehen bleiben?	Information_nachfragen
+TL	ja korrekt da stehen bleiben	Zusage
+TL	schauen Sie mal im Umkreis ob dort Rettungskräfte sich bewegen kommen	Einsatzbefehl
+UGV-1	ja ich fahre den Rettungskräften über meinen Angriffsweg entgegen und versuche sie zu lotsen	Zusage
+UAV	Thorsten für Dirk kommen	Kontakt_Anfrage
+TL	Thorsten hört kommen	Kontakt_Bestaetigung
+UAV	die Drohne startet wieder	Information_geben
+TL	ja verstanden die Drohne startet wieder	Information_geben
+TL	folgenden Auftrag an Roboter 2 suchen Sie den Standort des Roboters 1	Einsatzbefehl
+TL	und dort finden Sie Rettungskräfte die Orientierungsprobleme haben um an die verunfallte Person zu gelangen kommen	Einsatzbefehl
+UGV-2	Roboter 2 hat gehört	Information_geben
+UGV-2	aber teilweise unfähig das umzusetzen	Absage
+UGV-2	weil mein Roboter sich teilweise gar nicht bewegt	Information_geben
+TL	letzten Teil des Satzes habe ich nicht verstanden	Information_geben
+TL	wiederholen	Einsatzbefehl
+UGV-2	der Roboter ist momentan wieder ausgesetzt kann sich also gar nicht bewegen	Information_geben
+UGV-2	und ich hab Probleme den zu bewegen	Information_geben
+UGV-2	weil die Kameras auch nicht so funktionieren wie sie sollten	Information_geben
+TL	verstanden	Information_geben
+TL	wenn betriebsbereit Auftrag durchführen	Einsatzbefehl
+UGV-2	ja verstanden	Zusage
+TL	Dirk von Thorsten kommen	Kontakt_Anfrage
+UAV	Dirk hört	Kontakt_Bestaetigung
+TL	benötige Luftbild mit möglichst der leblosen Person die auf dem Wärmescan den ich hier habe zu sehen ist	Einsatzbefehl
+TL	als Anhaltspunkt in dem Bereich muss sich der Roboter 1 befinden kommen	Information_geben
+UAV	ist das ein Foto von mir?	Information_nachfragen
+TL	nein das ist ein Foto von dem Roboter 1	Absage
+TL	Auftrag lautet aus der Luft versuchen den Roboter 1 zu finden und dann abzufotografieren	Einsatzbefehl
+UAV	das ist verstanden wir schalten um auf Wärmebild und gucken	Zusage
+UGV-1	Teamleader von Roboter 1	Kontakt_Anfrage
+TL	Teamleader hört	Kontakt_Bestaetigung
+UGV-1	ich bin jetzt an dem Treppenabsatz sehe eine Person in orangefarbener Warnweste	Information_geben
+TL	verstanden Standort Treppenabsatz	Information_geben
+UGV-1	ja richtig	Information_geben
+TL	Dirk von Thorsten kommen	Kontakt_Anfrage
+UAV	Dirk hört	Kontakt_Bestaetigung
+TL	wir haben jetzt ein Trupp auf dem Weg zur verunfallten Person	Information_geben
+TL	neuer Auftrag Personsuche aus der Luft mittels Wärmebildkamera kommen	Einsatzbefehl
+UAV	Personensuche aus der Luft mittels Wärmebildkamera verstanden	Zusage
+TL	Roboter 2 von Thorsten kommen	Kontakt_Anfrage
+UGV-2	Roboter 2 hört	Kontakt_Bestaetigung
+TL	wie ist der Stand der Dinge?	Information_nachfragen
+UGV-2	bin auf dem Treppenabsatz aber weiter links gelegen	Information_geben
+UGV-2	und hab große Aussetzer	Information_geben
+UGV-2	alle paar Sekunden setzt mir der Roboter aus	Information_geben
+TL	verstanden Roboteraussetzer	Information_geben
+TL	in der Zwischenzeit schon irgend etwas an Personen festgestellt oder Lageveränderungen?	Information_nachfragen
+UGV-2	negativ	Absage
+TL	okay	Information_geben
+UGV-1	Teamleader von Roboter 1 kommen	Kontakt_Anfrage
+TL	Teamleader hört Roboter 1	Kontakt_Bestaetigung
+UGV-1	ja habe die Rettungstrupps zum Standort der vermissten Person gebracht	Information_geben
+TL	nächster Auftrag weitere Personensuche	Einsatzbefehl
+TL	absuchen der Fläche vielleicht finden wir die Person dort mit dem Wärmebild	Einsatzbefehl
+UGV-1	ja verstanden ich suche weiter	Zusage
+TL	Dirk von Thorsten kommen	Kontakt_Anfrage
+UAV	Dirk hört	Kontakt_Bestaetigung
+TL	Frage ist die Drohne noch in der Luft?	Information_nachfragen
+UAV	ja die ist immer noch in der Luft	Zusage
+TL	verstanden	Information_geben
+TL	Frage wie sieht's da mit der Brandausbreitung aus?	Information_nachfragen
+UAV	also keine Suche nach Vermissten mehr?	Information_nachfragen
+TL	guck mal auch nebenbei so ein bisschen nach dem Feuer	Einsatzbefehl
+UAV	negativ	Absage
+UAV	ich hab gerade Infrarot und diesen Kunstrauch sieht man dann nicht	Information_geben
+TL	ja verstanden	Information_geben
+TL	hab gerade gehört Feuer soll aus sein	Information_geben
+TL	noch suchen nach weiteren Personen	Einsatzbefehl
+UAV	Drohne landet wegen leerem Akku	Absage
+TL	ja hab ich mir fast gedacht	Information_geben
+UAV	Thorsten für Dirk	Kontakt_Anfrage
+TL	Thorsten hört kommen	Kontakt_Bestaetigung
+UAV	möchtest du normale oder Infrarot-Bilder haben?	Information_nachfragen
+TL	ich möchte Infrarot-Bilder haben mit dem Ziel Leckagen festzustellen beziehungsweise Wärmestrahlung	Information_geben
+TL	Roboter 1 von Thorsten kommen	Kontakt_Anfrage
+UAV	hier Roboter 1 kommen	Kontakt_Bestaetigung
+TL	zur Lage Menschenrettung durchgeführt und abgeschlossen	Information_geben
+TL	jetzt gilt der Auftrag auslaufende Chemikalien und Gefahrstoffe zu finden und zu orten	Einsatzbefehl
+UAV	ja verstanden	Zusage
+UAV	auf der Etage wo die Personen gefunden wurden befindet sich ein 200-Liter-Gefahrstoffbehälter Kennzeichnung umweltgefährdend	Information_geben
+UAV	Behältnis scheint dicht zu sein	Information_geben
+TL	stelle fest ein dichtes 200-Liter-Fass umweltgefährdend gekennzeichnet	Information_geben
+UAV	das ist korrekt	Information_geben
+TL	Robot 2 von Thorsten kommen	Kontakt_Anfrage
+UGV-2	Roboter 2 hört	Kontakt_Bestaetigung
+TL	Frage wie ist die Situation am Roboter?	Information_nachfragen
+UGV-2	ich hab einen großen Zeitunterschied zwischen Bewegung und Eingabe	Information_geben
+UGV-2	und ich bin auf dem Weg zum Roboter 1	Information_geben
+TL	ja verstanden	Information_geben
+TL	zur Lage die Personen sind alle gerettet und der medizinischen Versorgung zugeführt	Information_geben
+TL	neuer Auftrag lautet Suchen von Leckagen von Undichtigkeiten und Chemikalien	Einsatzbefehl
+UGV-2	Roboter 2 hat verstanden	Zusage
+UGV-1	Teamleader von Roboter 1 kommen	Kontakt_Anfrage
+TL	Teamleader hört kommen	Kontakt_Bestaetigung
+UGV-1	Treppenaufgang und dann direkt links blauer Kanister unbekannter Inhalt sieht auch ebenfalls dicht aus	Information_geben
+TL	wiederhole am Treppenausgang blauer Kanister	Information_geben
+UGV-1	ja richtig	Information_geben
+TL	verstanden	Information_geben
+TL	benötige Foto	Einsatzbefehl
+UGV-1	Foto ist versandt	Information_geben
+UAV	Thorsten für Dirk kommen	Kontakt_Anfrage
+TL	Thorsten hört kommen	Kontakt_Bestaetigung
+UAV	ich hab ein Bild jetzt geschickt auf einem Behältnis oben eine helle Person	Information_geben
+UAV	es könnten Personen sein das was hell leuchtet	Information_geben
+TL	ich werte das Bild aus	Information_geben
+UGV-1	Teamleader von Operator 1	Kontakt_Anfrage
+TL	Teamleader hört kommen	Kontakt_Bestaetigung
+UGV-1	ich habe dir gerade noch ein Foto von dem grünen Gefahrgutbehälter 200 liter rübergeschickt	Information_geben
+TL	von dem Fass?	Information_nachfragen
+UGV-1	ja von dem Fass	Zusage
+UGV-1	der ist in Sichtweite zu dem blauen Kanister	Information_geben
+TL	ja kann die Daten auswerten	Information_geben
+TL	hat zwar alles hier eine andere Farbe aber das Fass selber ist grün	Information_geben
+UGV-1	korrekt das Fass selber ist grün	Information_geben
+UAV	Thorsten für Dirk kommen	Kontakt_Anfrage
+TL	Thorsten hört kommen	Kontakt_Bestaetigung
+UAV	das Bild gerade würde ich ganz klar als Person einstufen	Information_geben
+UAV	ich kann dir gerne weitere Bilder zukommen lassen	Information_geben
+TL	ja würde ich mich darüber freuen	Zusage
+TL	bräuchte nur noch ein klareres Foto von der Person	Einsatzbefehl
+UAV	gut	Zusage
+UAV	links mittig ist die Person liegend	Information_geben
+TL	auf welchem Bild jetzt auf einem Wärmebild oder auf einem richtigen Foto?	Information_nachfragen
+UAV	auf einem Wärmebild ist links liegend die Person auf einem zylindrigen Gegenstand	Information_geben
+TL	ja verstanden	Information_geben
+TL	Hinweis an alle eingeteilten Kräfte Übungsende	Information_geben
+UGV-1	Roboter 1 hat verstanden Übungsende	Information_geben
+UGV-2	Roboter 2 hat verstanden Übungsende	Information_geben
+UAV	Drohne hat verstanden Übungsende	Information_geben

--- a/original_finetuning_for_intents/data_einsatzbefehl/train.tsv
+++ b/original_finetuning_for_intents/data_einsatzbefehl/train.tsv
@@ -1,0 +1,2264 @@
+TL	hier der Teamleader	Kontakt_Anfrage
+TL	die Drohne ist auch einsatzbereit?	Information_nachfragen
+UAV	ja, das ist korrekt	Zusage
+TL	UGV 2 von Einsatzleiter, kommen	Kontakt_Anfrage
+UGV-2	UGV 2 hört	Kontakt_Bestaetigung
+TL	wie ist bei dir, auch einsatzbereit?	Information_nachfragen
+TL	Standort, Frage?	Information_nachfragen
+UGV-2	ja, wir sind auch einsatzbereit	Zusage
+UGV-2	versuchen noch den Standort rauszufinden	Information_geben
+UGV-2	ich hab gerade ein Bild hochgeladen das müsstest du sehen	Information_geben
+TL	ja, Bild ist angekommen	Information_geben
+UAV	Einsatzleiter von UAV-Drohne	Kontakt_Anfrage
+TL	ja, ich höre	Kontakt_Bestaetigung
+UAV	sollen wir loslegen, und erkunden? oder hast du noch was?	Information_nachfragen
+TL	ja, startet mal und fliegt ja, startet erst mal	Zusage
+TL	UAV von Einsatzleiter, kommen	Kontakt_Anfrage
+UAV	hier ist die UAV	Kontakt_Bestaetigung
+TL	fliegt ihr in westlicher Richtung über dem eigentlichen Gelände und schickt mir dann mal ein Bild?	Einsatzbefehl
+UAV	ja, ist verstanden, westlich über das Gelände und ein Bild schicken	Zusage
+TL	UGV 2 von Einsatzleiter, kommen	Kontakt_Anfrage
+UGV-2	Teamleader, UGV 2 gerufen?	Information_nachfragen
+TL	ja richtig	Zusage
+TL	bewegt ihr euch mal in südlicher Richtung und sucht das Gelände mal nach gefährlichen Stoffen ab? kommen	Einsatzbefehl
+UGV-2	ja, verstanden, erkunden in südlicher Richtung	Zusage
+UGV-1	Frage: der Einsatzbefehl gilt auch für UGV 1?	Information_nachfragen
+TL	ja, richtig	Zusage
+TL	ihr nehmt aber die westliche Richtung	Information_geben
+UGV-1	westliche Richtung, verstanden	Information_geben
+UGV-1	Einsatzleiter von UGV 1, kommen	Kontakt_Anfrage
+TL	ja, höre	Kontakt_Bestaetigung
+UGV-1	die westliche Richtungserkundung auf dieser Ebene?	Information_nachfragen
+TL	habt ihr die Möglichkeit, die Ebene zu wechseln?	Information_nachfragen
+UGV-1	ja, es gibt Treppen	Zusage
+UGV-1	ich schick dir mal ein Bild, dass du einen Eindruck kriegst, wo ich gerade stehe	Information_geben
+TL	ja, richtig	Zusage
+UAV	Einsatzleiter von UAV	Kontakt_Anfrage
+TL	ich höre	Kontakt_Bestaetigung
+UAV	ich hab dir ein Bild geschickt von der Drohne aus der Luft mit Blickrichtung Westen	Information_geben
+TL	das ist verstanden	Information_geben
+TL	UAV von Einsatzleiter, kommen	Kontakt_Anfrage
+UAV	UAV hört	Kontakt_Bestaetigung
+TL	könnt ihr den Bereich mal abschwenken mit der Kamera, und nach eventuellen Brandnestern suchen?	Einsatzbefehl
+UAV	ja, wir suchen nach Brandnestern mittels Wärmebild-Kamera oder Infrarot-Kamera	Zusage
+UGV-1	Einsatzleiter von UGV 1	Kontakt_Anfrage
+TL	ich höre	Kontakt_Bestaetigung
+UGV-1	ich hab dir ein'n Schnappschuss erstellt	Information_geben
+UGV-1	kannst du mal gucken, ob dir das recht ist, auf dieser Ebene zu suchen?	Information_nachfragen
+UGV-1	das wäre jetzt der Blick in den westlichen Teil der Halle	Information_geben
+TL	UGV 1 von Einsatzleiter, kommen	Kontakt_Anfrage
+UGV-1	UGV 1 hört	Kontakt_Bestaetigung
+TL	bleibt mal auf der Ebene und fahrt weiter in westlicher Richtung, und erkundet dort	Einsatzbefehl
+UGV-1	weitererkunden in westlicher Richtung, verstanden	Zusage
+TL	UGV 2 von Einsatzleiter	Kontakt_Anfrage
+UGV-2	UGV 2 hört	Kontakt_Bestaetigung
+TL	wo ist dein Standort im Moment?	Information_nachfragen
+UGV-2	wir befinden uns auf einer Rampe	Information_geben
+UGV-2	ich schick dir nochmal einen Schnappschuss von ein bisschen weiter weg	Information_geben
+TL	ja	Zusage
+TL	UAV von Einsatzleiter	Kontakt_Anfrage
+UAV	hier ist die UAV	Kontakt_Bestaetigung
+UAV	wir haben zur Zeit technische Probleme	Information_geben
+UAV	und können noch keine neuen Bilder senden	Information_geben
+TL	ja, verstanden	Information_geben
+TL	UGV 1 von Einsatzleiter	Kontakt_Anfrage
+UGV-1	UGV 1 hört	Kontakt_Bestaetigung
+TL	habt ihr schon neue Erkenntnisse?	Information_nachfragen
+UGV-1	bisher negativ	Absage
+TL	ihr bewegt euch weiter in westlicher Richtung?	Information_nachfragen
+UGV-1	das ist korrekt	Zusage
+TL	UGV 2 von Einsatzleiter	Kontakt_Anfrage
+UGV-2	ja, ich UGV 2	Kontakt_Bestaetigung
+UGV-2	ich komme gleich mit 'nem neuen Bild	Information_geben
+UAV	Einsatzleiter von UAV	Kontakt_Anfrage
+TL	ich höre	Kontakt_Bestaetigung
+UAV	also, wir haben diese Ausrichtung Westen und dieses Gebäude angeguckt und konnten bisher keine Glutnester feststellen	Information_geben
+UAV	wir tauschen jetzt den Akku und fliegen dann nochmal aus einer anderen Richtung an	Information_geben
+UAV	au- aus	Sonstiges
+TL	ja, verstanden	Information_geben
+UGV-1	ja, Einsatzleiter von UGV 1, kommen	Kontakt_Anfrage
+TL	ich höre	Kontakt_Bestaetigung
+UGV-1	ja, wir stehen hier wohl auf einer Rampe, ich kann nämlich genau sagen wo die ist	Information_geben
+UGV-1	wir hätten die Möglichkeit, von hier aus in den Komplex reinzufahren und dort innen zu erkunden	Information_geben
+TL	ja, fahr mal rein	Zusage
+UGV-1	ja, verstanden	Information_geben
+TL	UGV 2 von Einsatzleiter	Kontakt_Anfrage
+UGV-2	UGV 2 hört	Kontakt_Bestaetigung
+TL	fahrt ihr runter oder fahrt ihr auch über diese Rampe?	Information_nachfragen
+UGV-2	also, aktuell stehe ich noch an dem flachen Bereich der Rampe	Information_geben
+TL	kannst du mir ein Bild schicken?	Einsatzbefehl
+UGV-2	ja, kommt sofort	Zusage
+UGV-1	Einsatzleiter von UGV 1, kommen	Kontakt_Anfrage
+TL	ich höre	Kontakt_Bestaetigung
+UGV-1	habe den westlichen Hallenteil bis zum Ende jetzt erkundet, keine weiteren Erkenntnisse	Information_geben
+UGV-1	ich hätte jetzt die Möglichkeit, auch in die erste Ebene hochzufahren	Information_geben
+TL	ja, dann fahrt mal hoch und erkundet da weiter	Zusage
+UGV-1	ja, ist verstanden	Information_geben
+UAV	Einsatzleiter von UAV	Kontakt_Anfrage
+UAV	U- UAV	Sonstiges
+TL	ich höre	Kontakt_Bestaetigung
+UAV	also, ich kann auch hier keine Glutnester erkennen	Information_geben
+TL	ja, verstanden	Information_geben
+TL	ihr seid also jetzt den eigentlichen Hochofenbereich abgeflogen, komplett, ja?	Information_nachfragen
+UAV	ja, wir gucken jetzt gerade aus nördlicher Richtung, oder auf den Hochofen, ja	Zusage
+TL	Rauchentwicklung ist von dort aus auch nicht zu sehen?	Information_nachfragen
+UAV	ja	Zusage
+UAV	ich guck mal gleich wieder	Information_geben
+UGV-2	UGV 2 von Einsatzleiter	Kontakt_Anfrage
+UGV-2	UGV 2 hört	Kontakt_Bestaetigung
+TL	du hattest mir gerade das Bild geschickt, ja?	Information_nachfragen
+UGV-2	ja	Zusage
+UGV-2	ist schon etwas länger her	Information_geben
+UGV-2	wir haben massive Probleme mit der Steuerung	Information_geben
+UGV-2	ja, da haben wir es gerade ein bisschen schwierig	Information_geben
+UGV-2	ich schick noch mal ein aktuelles Foto von dem Eingang, vor dem ich jetzt stehe	Information_geben
+TL	ja, verstanden	Information_geben
+UGV-2	Einsatzleiter von UGV 2, kommen	Kontakt_Anfrage
+TL	ich höre	Kontakt_Bestaetigung
+UGV-2	das Bild ist geteilt	Information_geben
+TL	ja, ist bei mir angekommen	Information_geben
+UGV-2	Frage: sollen wir da jetzt reinfahren?	Information_nachfragen
+TL	warte, ich muss eben erst gucken	Sonstiges
+TL	ja, fahrt da mal rein	Zusage
+UGV-2	ja, verstanden	Information_geben
+UGV-2	das müsste irgendwo im westlichen Bereich sein	Information_geben
+UAV	Einsatzleiter von UAV	Kontakt_Anfrage
+TL	ich höre	Kontakt_Bestaetigung
+UAV	ich hab dir ein Bild geschickt, was den Hochofen aus nördlicher Richtung zeigt	Information_geben
+UAV	ich kann keine Rauchentwicklung erkennen	Information_geben
+TL	ja, verstanden	Information_geben
+UAV	Einsatzleiter von UAV	Kontakt_Anfrage
+TL	ich höre	Kontakt_Bestaetigung
+UAV	also, wir haben jetzt doch eine leichte Rauchentwicklung auf der nördlichen Seite des Gebäudes	Information_geben
+UAV	ich schicke dir ein Bild	Information_geben
+UGV-1	Einsatzleiter von UAV 1	Kontakt_Anfrage
+TL	höre	Kontakt_Bestaetigung
+UGV-1	ich korrigiere - UGV 1	Sonstiges
+TL	ja, kommen Sie	Kontakt_Bestaetigung
+UGV-1	ja, ich stehe jetzt am Fuß der Rampe	Information_geben
+UGV-1	hab dir ein Bild geschickt	Information_geben
+UGV-1	kannst du mal was gucken, ob da was Interessantes ist	Information_geben
+TL	ja danke	Zusage
+UGV-1	zur Info, das ist der Blick in östlicher Richtung	Information_geben
+TL	UAV von Einsatzleiter	Kontakt_Anfrage
+UAV	ich hör' dich	Kontakt_Bestaetigung
+TL	wenn ich das richtig sehe, kommt der Rauch am rechten Behälter Blickrichtung Süd raus	Information_geben
+TL	könnt ihr da auch was ausmachen in Form von Wärmestrahlung?	Einsatzbefehl
+UAV	ja wir schalten gerade um, ich komme gleich wieder mit neuen Infos	Zusage
+TL	UGV 2 von Einsatzleiter	Kontakt_Anfrage
+UGV-2	UGV 2 hört	Kontakt_Bestaetigung
+TL	schickst du mir noch mal ein aktuelles Foto euren Standortes?	Einsatzbefehl
+UGV-2	ja, ich schick dir gleich ein Bild von UGV 1, wenn er an mir vorbei fährt	Zusage
+UAV	Einsatzleiter von UAV	Kontakt_Anfrage
+TL	ich höre	Kontakt_Bestaetigung
+UAV	ich hab dir ein Bild von der Wärmebild-Kamera geschickt	Information_geben
+UAV	unterhalb des Tankes ist Fleck, der auffällig ist, und recht oben am Tank	Information_geben
+UAV	guckst du mal?	Information_geben
+TL	ja, mache ich	Zusage
+UGV-2	Einsatzleiter von UGV 2, kommen	Kontakt_Anfrage
+TL	ich höre	Kontakt_Bestaetigung
+UGV-2	ja, ich habe nochmal ein Foto gezeigt	Information_geben
+UGV-2	UGV 1 ist gerade an uns vorbei gefahren	Information_geben
+UGV-2	sollen wir versuchen, uns anzuschließen?	Information_nachfragen
+UGV-2	abz- anzuschließen	Sonstiges
+TL	ja, macht ihr mal	Zusage
+UAV	Einsatzleiter von UAV	Kontakt_Anfrage
+TL	höre	Kontakt_Bestaetigung
+UAV	wir müssen gleich nochmal den Akku tauschen	Information_geben
+UAV	hast du danach noch einen Auftrag für uns?	Information_nachfragen
+TL	ja, landet erst mal, ihr kriegt einen neuen Auftrag	Zusage
+UAV	ja, ist verstanden	Information_geben
+TL	UGV 2 von Einsatzleiter	Kontakt_Anfrage
+UGV-2	UGV 2 hört	Kontakt_Bestaetigung
+TL	du sprachst eben von einer anderen Ebene habt ihr die schon erreicht?	Information_nachfragen
+UGV-2	wir haben aktuell immer noch Probleme mit der Steuerung	Absage
+UGV-1	UGV 1 erreicht gerade die erste Ebene	Zusage
+TL	das ist verstanden	Information_geben
+TL	schickst du mir dann auch von da mal ein Foto?	Einsatzbefehl
+UGV-1	ja, das ist verstanden	Zusage
+UAV	Einsatzleiter von UAV	Kontakt_Anfrage
+TL	ich höre	Kontakt_Bestaetigung
+UAV	wir wären wieder startklar, wenn du was neues für uns hast?	Information_geben
+TL	ja, ich melde mich gleich bei euch	Information_geben
+UGV-1	Einsatzleiter von UGV 1	Kontakt_Anfrage
+TL	ich höre	Kontakt_Bestaetigung
+UGV-1	Foto ist erstellt und geteilt	Information_geben
+UGV-1	man sieht die Rauchentwicklung und einen Behälter, das ist Blickrichtung Ost	Information_geben
+TL	könnt ihr mir Näheres zu dem Behälter geben?	Information_nachfragen
+UGV-1	ich fahr mal näher ran und erkunde	Information_geben
+TL	ja, verstanden	Information_geben
+TL	UGV 1 von Einsatzleiter	Kontakt_Anfrage
+UGV-1	UGV 1 hört	Kontakt_Bestaetigung
+TL	das Bild mit dem Behälter war in östlicher Richtung, war's korrekt?	Information_nachfragen
+UGV-1	das ist korrekt	Zusage
+UGV-1	ich schicke dir auch gleich nochmal ein Bild mit der Thermal-Kamera	Information_geben
+TL	ja, verstanden	Zusage
+UAV	Einsatzleiter von UAV	Kontakt_Anfrage
+TL	ich höre	Kontakt_Bestaetigung
+UAV	ja, wir haben uns gerade die Bilder noch einmal angeguckt	Information_geben
+UAV	da könnte nochmal was sein	Information_geben
+UAV	wir steigen nochmal auf und gucken uns das nochmal an	Information_geben
+TL	ja, insbesondere was die Wärmeentwicklung geht anbetrifft	Einsatzbefehl
+TL	da konnte man nicht viel erkennen	Information_geben
+UAV	ja, ich versuch, dir nochmal ein besseres Bild zu liefern	Zusage
+TL	ja, verstanden	Information_geben
+UGV-1	Einsatzleiter von UGV 1	Kontakt_Anfrage
+TL	höre	Kontakt_Bestaetigung
+UGV-1	schicke dir nochmal ein Bild	Information_geben
+UGV-1	wir haben hier einen Gefahrenzettel auf dem Behälter	Information_geben
+TL	ja, verstanden	Information_geben
+UGV-2	Einsatzleiter von UGV 2	Kontakt_Anfrage
+TL	ich höre	Kontakt_Bestaetigung
+UGV-2	ja, wir haben mittlerweile die Kontrolle gewonnen und sind jetzt auch bei UGV 1	Information_geben
+UGV-2	ich hab auch nochmal ein Bild geschickt	Information_geben
+TL	UGV 1 von Einsatzleiter	Kontakt_Anfrage
+TL	UGV 1 von Einsatzleiter	Kontakt_Anfrage
+UGV-1	UGV 1 hört	Kontakt_Bestaetigung
+TL	Frage: könnt ihr den Behälter mal von einer anderen Seite anfahren und erkunden, ob er noch verschlossen ist, oder ob da irgendwas austritt?	Einsatzbefehl
+UGV-1	ja, positiv, wird gemacht	Zusage
+UAV	Einsatzleiter von UAV	Kontakt_Anfrage
+TL	ich höre	Kontakt_Bestaetigung
+UAV	wir haben auf der Rückseite - also aus nördlicher Sicht an der Rauchentwicklung ein Objekt festgestellt, wir können keine Gefahrstoff-Kennzeichnung erkennen	Information_geben
+UAV	ich hab dir jetzt zwei Bilder geschickt, eine Detailaufnahme	Information_geben
+TL	ja	Information_geben
+TL	ich schau mal rein	Information_geben
+UGV-1	Einsatzleiter von UGV 1	Kontakt_Anfrage
+TL	ich höre	Kontakt_Bestaetigung
+UGV-1	der Behälter scheint leer zu sein, ich hab dir ein Bild geschickt	Information_geben
+UAV	Einsatzleiter von UAV	Kontakt_Anfrage
+TL	ja, ich höre	Kontakt_Bestaetigung
+UAV	ich hab dir - oder ich schick dir gleich nochmal ein Bild rüber, du siehst auf der Rückseite definitiv zwei Orte, wo sich noch Glutnester befinden	Information_geben
+TL	ja, verstanden	Zusage
+UAV	der eine Ort, das sind zwei kleine Stellen, das ist unter dem Fass, was ich gerade schon mal geschickt habe, und rechts davon siehst du auch da im Bild sehr deutlich, 'ne Wärmesignatur, die etwas größer ist	Information_geben
+TL	ja, verstanden	Information_geben
+UGV-1	Einsatzleiter von UGV 1	Kontakt_Anfrage
+TL	ich höre	Kontakt_Bestaetigung
+UGV-1	reichen dir die Bilder?	Information_nachfragen
+UGV-1	dann würde ich die Erkundung auf dieser Ebene weiter fortsetzen	Information_geben
+TL	ja, reicht mir erst mal aus	Zusage
+TL	setz die Erkundung fort	Zusage
+UGV-2	Einsatzleiter von UGV 2, kommen	Kontakt_Anfrage
+TL	ich höre	Kontakt_Bestaetigung
+UGV-2	ja, kriegen wir auch noch einen Auftrag?	Information_nachfragen
+TL	ja	Zusage
+TL	ich komme sofort wieder	Sonstiges
+TL	UGV 2 von Einsatzleiter	Kontakt_Anfrage
+UGV-2	UGV 2 hört	Kontakt_Bestaetigung
+TL	seht ihr die drei Hochbehälter?	Information_nachfragen
+UGV-2	negativ	Absage
+UGV-2	aber ich sehe gerade Rauchentwicklung von hier aus	Information_geben
+UGV-2	soll ich mal ein Foto machen?	Information_geben
+UGV-1	Einsatzleiter von UGV 1	Kontakt_Anfrage
+TL	ich höre	Kontakt_Bestaetigung
+UGV-1	ich habe jetzt hinter dem ersten Hochofen in östlicher Richtung einen weiteren Behälter gefunden	Information_geben
+TL	ja, schickst du mir nochmal ein Bild?	Einsatzbefehl
+UGV-1	ja, ist verstanden	Zusage
+UGV-1	wir haben auch jetzt hier erhöhte Rauchentwicklung	Information_geben
+TL	ja, verstanden	Information_geben
+UAV	Einsatzleiter von UAV	Kontakt_Anfrage
+TL	ich höre	Kontakt_Bestaetigung
+UAV	ich hab dir doch noch ein Bild geschickt in Infrarot	Information_geben
+UAV	und zwar sind an dem Objekt - an dem Tank selber unten links ist 'ne Wärmesignatur, möglicherweise oben am Tank rechte Seite und rechts des Tankes	Information_geben
+UAV	- an der - an dem Tank	Sonstiges
+TL	ja, verstanden	Information_geben
+TL	UGV 2 von Einsatzleiter	Kontakt_Anfrage
+UGV-2	UGV 2 hört	Kontakt_Bestaetigung
+TL	Frage: wo ist jetzt euer Standort?	Information_nachfragen
+UGV-2	wir sind noch in der Nähe von dem ersten Behälter, der von UGV 1 untersucht wurde	Information_geben
+TL	dann bewegt ihr euch einmal in östlicher Richtung?	Information_nachfragen
+UGV-2	dafür müsstest du mal sagen, wo wir ungefähr sind	Information_nachfragen
+UGV-2	weil das können wir selber klar nicht feststellen	Information_geben
+UGV-1	Einsatzleiter von UGV 1	Kontakt_Anfrage
+TL	ich höre	Kontakt_Bestaetigung
+UGV-1	ja, ich bin ein bisschen näher an den gefundenen - an den zweiten gefundenen Behälter rangefahren	Information_geben
+UGV-1	scheint keine Flüssigkeit auszutreten, und Gefahrenzettel oder andere Signaturen sind auch nicht zu sehen	Information_geben
+UGV-1	Si- andere Signaturen	Sonstiges
+TL	ja, verstanden	Information_geben
+TL	UGV 2 von Einsatzleiter	Kontakt_Anfrage
+UGV-2	UGV 2 hört	Kontakt_Bestaetigung
+TL	schick mir mal ein Foto, wo ihr steht, damit ich ein bisschen zuordnen kann	Einsatzbefehl
+UGV-2	ja	Zusage
+UGV-2	Einsatzleiter von UGV 2	Kontakt_Anfrage
+TL	ja	Kontakt_Bestaetigung
+UGV-2	ja, Foto ist geteilt	Information_geben
+UGV-1	Einsatzleiter von UGV 1	Kontakt_Anfrage
+TL	ja, ich höre	Kontakt_Bestaetigung
+UGV-1	ja, ich hab nochmal 'ne Nahaufnahme von dem Fass und 'ne Wärmesignatur von dem Fass geschickt	Information_geben
+UGV-1	scheint so, als läge das Fass auf dem Gefahrzettel oder ähnlich	Information_geben
+UGV-1	ich bin drauf, ich versuch das mal zu rollen	Information_geben
+TL	ja, verstanden	Information_geben
+TL	UGV 2 von Einsatzleiter	Kontakt_Anfrage
+UGV-2	UGV 2 hört	Kontakt_Bestaetigung
+TL	Frage: das Bild, das ich gerade bekommen hab' ist mit Blick auf zwei runden Öffnungen, ist das richtig?	Information_nachfragen
+UGV-2	ja, das ist korrekt	Zusage
+TL	UGV 2 von Einsatzleiter	Kontakt_Anfrage
+UGV-2	UGV 2 hört	Kontakt_Bestaetigung
+TL	dann müsst ihr euch von da aus in östlicher Richtung bewegen	Einsatzbefehl
+UGV-2	ja	Zusage
+UGV-2	wie ist da meine Blickrichtung auf dem Bild?	Information_nachfragen
+TL	schwenk mal nach rechts dann müsstet ihr eigentlich in die Halle reinblicken	Information_geben
+UGV-2	ja, verstanden	Information_geben
+UAV	Einsatzführer von UAV	Kontakt_Anfrage
+TL	ja, ich höre	Kontakt_Bestaetigung
+UAV	ich müsste erneut zurück wegen Akku Tausch	Information_geben
+UAV	möglicherweise an dem Objekt sind noch mehrere Wärmequellen, ich kann's zur Zeit nicht genau sagen	Information_geben
+TL	ja, dann tausch das Akku nochmal aus und flieg die Strecke nochmal ab	Einsatzbefehl
+UAV	so machen wir das	Zusage
+UGV-1	Einsatzleiter von UGV 1	Kontakt_Anfrage
+TL	ich höre	Kontakt_Bestaetigung
+UGV-1	ja, ich hab das Fass jetzt gedreht, man kann jetzt die Signatur des Fasses erkennen Gefahrzettel	Information_geben
+UGV-1	schau dir das bitte mal an, beide Bilder sind geteilt	Information_geben
+TL	ja, verstanden	Zusage
+UGV-1	ich würde dann die Erkundung in östlicher Richtung auf dieser Ebene weiter fortsetzen	Information_geben
+TL	ja, verstanden	Zusage
+TL	ihr setzt die Erkundung in östlicher Richtung weiter fort	Zusage
+TL	UGV 2 von Einsatzleiter	Kontakt_Anfrage
+UGV-2	UGV 2 hört	Kontakt_Bestaetigung
+TL	Frage: wo ist euer Standort inzwischen?	Information_nachfragen
+UGV-2	immer noch nicht klar	Information_geben
+TL	UAV von Einsatzleiter	Kontakt_Anfrage
+UAV	hier ist die UAV	Kontakt_Bestaetigung
+TL	Frage: könnt ihr aus eurer Position den UGV 1 sehen?	Information_nachfragen
+UAV	wir sind unterwegs und melden uns gleich nochmal	Sonstiges
+TL	ja, dann könnt ihr direkt mal erkunden wie aus der Position, wo UGV eins sich momentan befindet, das andere Fass zu sehen war	Einsatzbefehl
+	UGV zw- eins	Sonstiges
+UAV	ja, ist verstanden	Zusage
+UGV-1	UAV von UGV 1, kommen	Kontakt_Anfrage
+UAV	hier ist UAV	Kontakt_Bestaetigung
+UGV-1	ja, zur Info - ich müsste mich jetzt genau zwischen beiden Hochöfen befinden	Information_geben
+UAV	hast du eine Ebene? auf welcher Ebene?	Information_nachfragen
+UGV-1	ja, auf der ersten Ebene, zu den Rampen hin	Information_geben
+UAV	ja, ich sehe dich	Information_geben
+UAV	Einsatzleiter von UAV	Kontakt_Anfrage
+TL	ja, ich höre	Kontakt_Bestaetigung
+UAV	ja, du hattest gerade noch mal einen Auftrag, kann du den mir wiederholen?	Information_nachfragen
+TL	ja, ihr hattet doch eben zwei Fässer ausgemacht, von oben, könnt ihr den UGV 2 dorthin lotsen?	Information_nachfragen
+UAV	ja, ist negativ	Absage
+UAV	das zweite war eine Wärmesignatur, die ist genau in ähnlicher Position, wo sich das UAV gerade befindet – das erdgebundene Fahrzeug	Information_geben
+UAV	das U- das erdgebundene	Sonstiges
+TL	ja, das ist verstanden	Information_geben
+TL	UGV 2 von Einsatzleiter	Kontakt_Anfrage
+UGV-2	UGV 2 hört	Kontakt_Bestaetigung
+TL	wie weit seid ihr?	Information_nachfragen
+UGV-2	ja, ich bin jetzt wieder im Außenbereich	Information_geben
+UGV-2	hier liegt ein grünes Fass, und es ist starke Rauchentwicklung zu erkennen	Information_geben
+TL	ja, schickst du mir mal ein Foto?	Einsatzbefehl
+UGV-2	ja, Foto kommt	Zusage
+TL	UGV 1 von Einsatzleiter	Kontakt_Anfrage
+UGV-1	UGV 1 hört	Kontakt_Bestaetigung
+TL	die Rauchentwicklung, die das UAV gemeldet hat, könnt ihr da näher erkunden, inwiefern wir da noch mit Kräften vorgehen können?	Einsatzbefehl
+UGV-1	ja, das kann ich machen	Zusage
+UGV-1	ich breche dann die Erkundung in östlicher Richtung ab	Information_geben
+TL	ja, verstanden	Information_geben
+UAV	Einsatzleiter von UAV	Kontakt_Anfrage
+TL	ich höre	Kontakt_Bestaetigung
+UGV-1	nähere mich der Rauchquelle	Information_geben
+UAV	ich hab dir gerade noch mal ein Bild geteilt, und zwar ist genau in dem Fadenkreuz sichtbar, das sind zwei Punkte, die Wärme abstrahlen, da müsstest du nochmal nachgucken	Information_geben
+TL	ja, das ist verstanden	Information_geben
+UAV	da bewegt sich das erdgebundene Fahrzeug gerade darauf zu	Information_geben
+UGV-2	Einsatzleiter von UGV 2, kommen	Kontakt_Anfrage
+TL	ich höre	Kontakt_Bestaetigung
+UGV-2	ja, ich hab jetzt nochmal zwei Bilder gemacht, einmal von der Rauchentwicklung und einmal von dem grünen Fass, was hier liegt	Information_geben
+TL	ja, verstanden	Information_geben
+UGV-2	und ich glaube, da kommt UGV 1 auch wieder angerollt	Information_geben
+UGV-1	ja, das ist korrekt	Information_geben
+UAV	UGV 1 von UAV 1	Kontakt_Anfrage
+UGV-1	ich höre dich	Kontakt_Bestaetigung
+UAV	ich teile dir jetzt noch ein Bild, wo du zwei Punkte siehst, die Wärmesignaturen plus dich, deine Position und deinen Begleiter	Information_geben
+UGV-1	ja, ist verstanden	Information_geben
+UAV	die Wärmesignaturen sind schwarze Punkte	Information_geben
+UGV-1	Frage: ist das schon erfolgt?	Information_nachfragen
+UAV	Bild ist draußen, ich hab's geteilt	Zusage
+UAV	kannst du die Bilder sehen? UGV?	Information_nachfragen
+UGV-1	nein, negativ	Absage
+TL	UAV von Einsatzleiter	Kontakt_Anfrage
+UAV	hier ist die UAV	Kontakt_Bestaetigung
+TL	konntet ihr im Außenbereich noch weitere Fässer feststellen, oder war's das einzigste?	Information_nachfragen
+UAV	bisher ist das einzige	Information_geben
+TL	ja, verstanden	Information_geben
+UAV	UGV 1 von UAV	Kontakt_Anfrage
+UGV-1	ja	Kontakt_Bestaetigung
+UGV-1	ich hab die brennenden Punkte gefunden	Information_geben
+UAV	ja, das ist schon mal gut, ja	Information_geben
+TL	UGV 1 von Einsatzleiter	Kontakt_Anfrage
+UGV-1	ich höre dich	Kontakt_Bestaetigung
+TL	ja, wie groß sind die brennenden Punkte, oder die Brandherde, was ist an Kräften erforderlich?	Information_nachfragen
+UGV-1	ja, die Punkte sind hier minimal, ich würde sagen zirka fünf bis zehn zentimeter im Durchmesser	Information_geben
+TL	ja, das ist verstanden	Information_geben
+TL	UAV von Einsatzleiter	Kontakt_Anfrage
+UAV	hier ist die UAV	Kontakt_Bestaetigung
+UAV	wir gehen runter zur Landung, Akkutausch	Information_geben
+TL	das ist verstanden	Information_geben
+UGV-1	Einsatzleiter von UGV 1, kommen	Kontakt_Anfrage
+TL	ich höre	Kontakt_Bestaetigung
+UGV-1	ja, ich hab dir ein Bild und 'ne Wärmebild von den brennenden Punkten geschickt	Information_geben
+TL	ist verstanden	Information_geben
+TL	ich kann momentan aus technischen Gründen nur leider nichts sehen	Information_geben
+UGV-1	ja, ist verstanden	Information_geben
+UAV	Einsatzleiter von UAV	Kontakt_Anfrage
+TL	höre	Kontakt_Bestaetigung
+UAV	ja, wir brauchen noch einen Augenblick	Information_geben
+UAV	tauschen eben die Kameras	Information_geben
+UAV	dann sind wir wieder dabei und suchen dann nach weiteren Fässern	Information_geben
+TL	ja, verstanden	Information_geben
+TL	in östlicher Richtung sollte das Gelände soweit abgesucht sein, denke ich?	Information_nachfragen
+UAV	ja, ist verstanden	Information_geben
+UAV	wobei wir jetzt nur westlich gesucht haben, von meinem Standpunkt aus	Absage
+TL	okay	Information_geben
+TL	an allen - an alle Einsatz- eingesetzten Kräfte, UGV 1, UGV 2 und UAV	Kontakt_Anfrage
+TL	Übungsende	Information_geben
+UGV-1	UGV 1, verstanden	Information_geben
+UGV-2	UGV 2, verstanden	Information_geben
+UAV	UAV auch verstanden	Information_geben
+WHS	Zugführer von WHS kommen	Kontakt_Anfrage
+ZF	Gruppenführer von Zugführer kommen	Kontakt_Anfrage
+GF	Gruppenführer hört	Kontakt_Bestaetigung
+ZF	Frage Lautstärke Verständigung kommen	Information_nachfragen
+GF	Ja Lautstärke und Verständigung gut kommen	Zusage
+ZF	Ja das ist so verstanden ende	Information_geben
+GF	Ja ende	Information_geben
+ZF	Das WHS von Zugführer kommen	Kontakt_Anfrage
+ZF	D2 von Zugführer kommen	Kontakt_Anfrage
+D2	D2 hier kommen	Kontakt_Bestaetigung
+ZF	Frage Lautstärke und Verständigung kommen	Information_nachfragen
+D2	Nochmal bitte kommen	Einsatzbefehl
+ZF	Frage Lautstärke und Verständigung kommen	Information_nachfragen
+D2	Lautstärke und Verständigung sind super kommen	Zusage
+ZF	Das ist verstanden ende	Information_geben
+ZF	WHS von Zugführer kommen	Kontakt_Anfrage
+WHS	Ja ich höre kommen	Kontakt_Bestaetigung
+ZF	Bei dir auch Frage Lautstärke und Verständigung kommen	Information_nachfragen
+WHS	Lautstärke und Verständigung ende	Zusage
+ZF	D1 von Zugführer kommen	Kontakt_Anfrage
+ZF	D1 von Zugführer kommen	Kontakt_Anfrage
+D1	D1 hier	Kontakt_Bestaetigung
+ZF	Ja auch für euch Frage Lautstärke und Verständigung kommen	Information_nachfragen
+D1	Lautstärke OK	Zusage
+ZF	Das ist so verstanden	Information_geben
+ZF	Frage seid ihr einsatzbereit kommen	Information_nachfragen
+D1	Sind einsatzbereit kommen	Zusage
+ZF	Ja das ist verstanden ende	Information_geben
+ZF	Gruppenführer von Zugführer kommen	Kontakt_Anfrage
+GF	Gruppenführer hört	Kontakt_Bestaetigung
+ZF	Ja für sie Aufträge einmal Kommunikation zu den Robotertrupps checken und fragen ob Einsatzbereitschaft kommen	Einsatzbefehl
+GF	Einmal die Kommunikation der Robotertrupps checken und die Einsatzbereitschaft herstellen	Zusage
+ZF	Das ist so korrekt Ende	Information_geben
+GF	Ja verstanden ende	Information_geben
+ZF	D2 von Zugführer kommen	Kontakt_Anfrage
+D2	D2 hier kommen	Kontakt_Bestaetigung
+ZF	Frage seit ihr einsatzbereit kommen	Information_nachfragen
+D2	Wir haben gerade kein <unverständlich> und wir müssen noch ins Auto fahren.	Absage
+D2	Also circa 5 Minuten kommen	Information_geben
+ZF	Das ist soweit verstanden	Information_geben
+ZF	dann bitte selbständig anfunken kommen	Einsatzbefehl
+D2	Verstanden ende	Zusage
+ZF	WHS von Zugführer kommen	Kontakt_Anfrage
+WHS	WHS hier kommen	Kontakt_Bestaetigung
+ZF	Frage sind sie einsatzbereit kommen	Information_nachfragen
+WHS	Nur eine Sekunde ende	Information_geben
+ZF	Gruppenführer von Zugführer kommen	Kontakt_Anfrage
+GF	Gruppenführer hört	Kontakt_Bestaetigung
+ZF	Ja für sie zur Information der D1 ist startklar der D2 brauch noch circa 5 Minuten bis zur Einsatzbereitschaft kommen	Information_geben
+GF	Ja verstanden ende	Information_geben
+WHS	Zugführer von WHS	Kontakt_Anfrage
+ZF	Hier Zugführer kommen	Kontakt_Bestaetigung
+WHS	Wir wären bereit ende	Information_geben
+ZF	Das ist verstanden ende	Information_geben
+GF	Zugführer von Gruppenführer kommen	Kontakt_Anfrage
+ZF	Ja hier Zugführer kommen	Kontakt_Bestaetigung
+GF	Der D3 und D5 einsatzbereit kommen	Information_geben
+ZF	D3 und D5 ist einsatzbereit das ist verstanden	Information_geben
+D2	Zugführer von D2 kommen	Kontakt_Anfrage
+ZF	Ja hier Zugführer kommen	Zusage
+ZF	D2 von Zugführer kommen	Kontakt_Anfrage
+D2	D2 hier kommen	Kontakt_Bestaetigung
+ZF	Ja sie wollten etwas sagen kommen	Information_nachfragen
+D2	D2 ist einsatzbereit kommen	Information_geben
+ZF	D2 ist einsatzbereit das ist verstanden	Information_geben
+ZF	Bitte auf Übungsbeginn warten kommen	Einsatzbefehl
+D2	Verstanden ende	Zusage
+ZF	An alle einsatzkräfte Übungsbeginn kommen	Information_geben
+WHS	WHS hier verstanden	Information_geben
+ZF	Gruppenführer von Zugführer kommen	Kontakt_Anfrage
+GF	Gruppenführer hört	Kontakt_Bestaetigung
+ZF	Einsatzszenario ist jetzt beginnend	Information_geben
+GF	Einsatzszenario beginnt Verstanden	Information_geben
+ZF	Verstanden ende	Information_geben
+ZF	Gruppenführer von Zugführer kommen	Kontakt_Anfrage
+GF	Gruppenführer hört	Kontakt_Bestaetigung
+ZF	Einmal bitte zum Gefahrenbereich vor den Eingang der Halle kommen	Einsatzbefehl
+GF	Ja verstanden	Zusage
+ZF	D1 von Zugführer kommen	Kontakt_Anfrage
+D1	D1 hört kommen	Kontakt_Bestaetigung
+ZF	Die Einsatzstelle wurde begangen. Wir haben einen Gefahrstoffunfall in einem Lager.	Information_geben
+ZF	Für sie Erkundungsauftrag außerhalb der Halle danach bei mir melden kommen	Einsatzbefehl
+ZF	Gruppenführer von Zugführer kommen	Kontakt_Anfrage
+GF	Gruppenführer hört	Kontakt_Bestaetigung
+ZF	der erste erkundungsflug ist jetzt mit der ersten Drohne gestartet worden kommen	Information_geben
+GF	Ja erster erkundungsflug mit der Drohne gestartet verstanden kommen	Information_geben
+ZF	WHS von Zugführer kommen	Kontakt_Anfrage
+WHS	Hier WHS kommen	Kontakt_Bestaetigung
+WHS	WHS hört kommen	Kontakt_Bestaetigung
+ZF	WHS für sie zur Information die Drohne D1 ist zur Außenerkundung vor	Information_geben
+ZF	Für sie Auftrag Erkundung innen der Halle kommen	Einsatzbefehl
+WHS	WHS hat verstanden kommen Erkundung innen verstanden <eh> kommen	Zusage
+ZF	Ja das ist verstanden ende	Information_geben
+ZF	Gruppenführer von Zugführer kommen	Kontakt_Anfrage
+GF	Gruppenführer hört	Kontakt_Bestaetigung
+ZF	Für sie zur Information der D1 ist zur Erkundung des Außenbereiches vor die WHS Drohne ist zur Innenerkundung vor kommen	Information_geben
+GF	Ja das ist verstanden ende	Information_geben
+ZF	Für sie bitte die Inbetriebnahme der Roboter D3 und D5 kommen	Einsatzbefehl
+GF	Inbetriebnahme D3 und D5 verstanden	Zusage
+ZF	Das ist so korrekt sie warten bitte noch auf weitere Einsatzbefehle kommen	Einsatzbefehl
+GF	Wir warten in Bereitschaft verstanden	Zusage
+ZF	D1 von Zugführer kommen	Kontakt_Anfrage
+D1	D1 hört	Kontakt_Bestaetigung
+ZF	Frage hat der Erkundungsauftrag Lagerhalle außen schon Erkenntnisse hervorgebracht kommen	Information_nachfragen
+D1	Bisher nichts zu sehen	Absage
+ZF	Von außen keine Erkenntnise ist das korrekt kommen	Information_nachfragen
+ZF	WHS von Zugführer kommen	Kontakt_Anfrage
+WHS	WHS hört	Kontakt_Bestaetigung
+ZF	Frage ich kann das bild ihrer Drohne auf dem Bildschirm sehen	Information_geben
+ZF	können sie die Kamera so positionieren dass man das gefahrgut kennzeichen sieht kommen	Einsatzbefehl
+WHS	WHS hat verstanden kommen	Zusage
+ZF	WHS von Zugführer kommen	Kontakt_Anfrage
+WHS	WHS hört	Kontakt_Bestaetigung
+ZF	ein stückchen näher ran	Einsatzbefehl
+WHS	Ja habe verstanden ende	Zusage
+ZF	Ja perfekt so ist es zu erkennen	Information_geben
+ZF	die nummer wird jetzt in die Datenbank eingegeben	Information_geben
+ZF	Für sie WHS Rückzug aus der Lagerhalle erkundungsauftrag beendet kommen	Einsatzbefehl
+WHS	WHS hat verstanden ende	Zusage
+ZF	Gruppenführer von Zugführer kommen	Kontakt_Anfrage
+GF	Gruppenführer hört	Kontakt_Bestaetigung
+ZF	Ja Erkundungsergebnisse von dem Innenflug haben ergeben es handelt sich nach HON nummer um Schwefelsäure	Information_geben
+ZF	keine Einsatzkraft betritt den Gefahrenbereich kommen	Information_geben
+GF	Erkundung ergeben Stoffidentifikation Schwefelsäure keine Einsatzkraft betritt den Gefahrenbereich verstanden	Information_geben
+ZF	Es handelt sich um einen umgekippten 20Liter Kanister der vom Regal runtegefallen ist und sich geöffnet handelt	Information_geben
+ZF	Für sie Auftrag es wird eine manipulation vorbereitet mit dem D2 kommen	Einsatzbefehl
+ZF	Falsch den hast du ja gar nicht	Sonstiges
+ZF	D2 von Zugführer kommen	Kontakt_Anfrage
+D2	D2 hört kommen	Kontakt_Bestaetigung
+GF	Die manipulation wird vom Trupp D2 vorgenommen wir warten weiter ab	Information_geben
+ZF	Für sie zur Information es handelt sich um folgenden stoff Schwefelsäure	Information_geben
+ZF	für sie als Auftrag mit dem D2 einen umgefallenen Kanister der sich geöffnet hat der die Flüssigkeit enthält aufnehmen und in ein Überfass befördern kommen	Einsatzbefehl
+D2	Verstanden Auftrag wird ausgeführt ende	Zusage
+ZF	Gruppenführer von Zugführer kommen	Kontakt_Anfrage
+ZF	D2 von Zugführer kommen	Kontakt_Anfrage
+D2	D2 hört kommen	Kontakt_Bestaetigung
+ZF	Frage an sie sie hatten auch das aufnahmebild vom inneren der Lagerhalle gesehen kommen	Information_nachfragen
+D2	Ja	Zusage
+ZF	D1 von Zugführer kommen	Kontakt_Anfrage
+D1	D1 hier kommen	Kontakt_Bestaetigung
+ZF	Für sie Paralleleinsatz der D2 geht zur Manipulation in die Lagerhalle vor	Information_geben
+ZF	für sie Bereitstellung eines Luftbildes aus der Halle kommen	Einsatzbefehl
+D1	Verstanden ende	Zusage
+ZF	Gruppenführer von Zugführer kommen	Kontakt_Anfrage
+GF	Sie haben sprechwunsch	Kontakt_Bestaetigung
+ZF	Das ist so korrekt	Information_geben
+ZF	der befindet sich gerade in der Anfahrt zum Gefahrgutobjekt	Information_geben
+ZF	für sie logistische Unterstützung durch den D3 mit dem Überfass kommen	Einsatzbefehl
+GF	D2 auf der Anfahrt zur Manipulation D3 zur Unterstützung vor das ist verstanden kommen	Zusage
+ZF	Ja das ist so korrekt ende	Information_geben
+ZF	D2 von Zugführer kommen	Kontakt_Anfrage
+D2	Was soll mit dem Kanister geschehen kommen	Information_nachfragen
+ZF	Ja das ist so korrekt warten sie noch auf den D3 der wird ihnen als Logistikaufgabe das Überfass bereitstellen kommen	Information_geben
+ZF	D2 von Zugführer kommen	Kontakt_Anfrage
+D2	D2 hört kommen	Kontakt_Bestaetigung
+ZF	Ja für sie zur Information bitte warten bis der D3 als Logistikunterstützung kommt	Einsatzbefehl
+ZF	er wird ihnen das Überfass zum sichern des Behältnisses bereitstellen kommen	Information_geben
+D2	Verstanden wir warten kommen	Zusage
+ZF	Ja das ist soweit verstanden	Information_geben
+ZF	Gruppenführer von Zugführer kommen	Kontakt_Anfrage
+GF	Gruppenführer hört	Kontakt_Bestaetigung
+ZF	Frage status D3 kommen	Information_nachfragen
+GF	Der D3 ist einsatzbereit und wartet auf einen Befehl	Information_geben
+ZF	Der D3 fährt zum Objekt vor der D2 ist schon dort stellt das Überfass bereit kommen	Einsatzbefehl
+GF	D3 fährt zum D2 vor und Vorbereitung des Überfasses kommen	Zusage
+ZF	Ja so korrekt ende	Information_geben
+GF	Zugführer von Gruppenführer kommen	Kontakt_Anfrage
+ZF	Hier Zugführer kommen	Kontakt_Bestaetigung
+GF	Die Standorte der Roboter sind im Lagebild nicht zu erkennen kommen	Information_geben
+ZF	Ja das ist verstanden	Information_geben
+ZF	gebe das an den Techniker hier weiter kommen	Information_geben
+GF	Ja verstanden ende	Information_geben
+ZF	D2 von Zugführer kommen	Kontakt_Anfrage
+D2	D2 hört kommen	Kontakt_Bestaetigung
+ZF	D3 mit Überfass ist am Standort angekommen	Information_geben
+ZF	für sie Beginn des Auftrages Bergung des Behältnisses kommen	Einsatzbefehl
+D2	Auftrag wird ausgeführt kommen	Zusage
+ZF	Ja das ist so korrekt ende	Information_geben
+D1	Zugführer D1 bitte kommen	Kontakt_Anfrage
+ZF	Hier Zugführer kommen	Kontakt_Bestaetigung
+D1	D1 müsste nachladen bitte kommen	Information_geben
+ZF	Bitte die Aussage wiederholen kommen	Einsatzbefehl
+D1	D1 müsste neue Batterien bekommen dazu müssen wir landen bitte kommen	Information_geben
+ZF	WHS von Zugführer kommen	Kontakt_Anfrage
+WHS	Hier WHS kommen	Kontakt_Bestaetigung
+ZF	Der D1 ist jetzt gerade im Akkuwechsel	Information_geben
+ZF	für sie Übergangsauftrag Bilddarstellung in der Lagerhalle innen kommen	Einsatzbefehl
+WHS	Auftrag verstanden ende	Zusage
+ZF	D2 von Zugführer kommen	Kontakt_Anfrage
+D2	D2 hört kommen	Kontakt_Bestaetigung
+ZF	Frage ist die Position des Überfasses ausreichend kommen	Information_nachfragen
+D2	Die Position von D3 ist OK kommen	Zusage
+ZF	Ja das ist verstanden ende	Information_geben
+WHS	Zugführer an WHS kommen	Kontakt_Anfrage
+D1	Zugführer von D1	Kontakt_Anfrage
+ZF	Hier Zugführer kommen	Kontakt_Bestaetigung
+D1	D1 ist wieder bereit bitte kommen	Information_geben
+ZF	Ja das ist verstanden	Information_geben
+ZF	für sie noch kurze Pause WHS ist gerade im Erkundungsflug kommen	Information_geben
+D1	Haben verstanden ende	Information_geben
+ZF	Gruppenführer von Zugführer kommen	Kontakt_Anfrage
+GF	Gruppenführer hört	Kontakt_Bestaetigung
+ZF	Frage Status Lagebildsystem	Information_nachfragen
+GF	Ja die Roboter D1 und D2 im Lagebild ersichtlich kommen	Information_geben
+ZF	Ja das ist verstanden	Information_geben
+GF	D3 und D5 können nicht im Lagebild dargestellt werden	Information_geben
+ZF	D3 und D5 können nicht im Lagebild dargestellt werden das ist verstanden	Information_geben
+D2	Zugführer von D2 kommen	Kontakt_Anfrage
+ZF	Hier Zugführer kommen	Kontakt_Bestaetigung
+D2	D2 hat den Kanister aufgenommen und fährt ihn jetzt zu D3 kommen	Information_geben
+ZF	Ja das ist verstanden	Information_geben
+ZF	bitte melden wenn durchgeführt	Einsatzbefehl
+ZF	WHS von Zugführer kommen	Kontakt_Anfrage
+WHS	hier WHS kommen	Kontakt_Bestaetigung
+ZF	Für sie ist der Erkundungsauftrag beendet kommen	Information_geben
+WHS	Haben verstanden ende	Information_geben
+ZF	D1 mitgehört sie können wieder die Innenerkundung starten kommen	Einsatzbefehl
+D1	Verstanden ende	Zusage
+ZF	WHS von Zugführer kommen	Kontakt_Anfrage
+WHS	Hier WHS kommen	Kontakt_Bestaetigung
+ZF	Für sie Erkundungsauftrag Panoramabild der gesammten Lagerhalle kommen	Einsatzbefehl
+WHS	Soll das Panoramabild über der Lagerhalle gemacht werden kommen	Information_nachfragen
+ZF	Ja das ist so korrekt kommen	Zusage
+WHS	haben verstanden ende	Information_geben
+ZF	Gruppenführer von Zugführer kommen	Kontakt_Anfrage
+GF	Gruppenführer hört	Kontakt_Bestaetigung
+ZF	Für sie auch Erkundungsauftrag mit dem D5 an der linken Flanke außerhalb der Lagerhalle Erkundung kommen	Einsatzbefehl
+GF	Erkundungsauftrag mit dem D5 linke Seite der Lagerhalle kommen	Zusage
+ZF	Ja das ist so korrekt	Information_geben
+ZF	Gruppenführer von Zugführer kommen	Kontakt_Anfrage
+GF	Gruppenführer hört	Kontakt_Bestaetigung
+ZF	Wie sieht der Status dafür aus den D3 gleich mit geschlossenem Überfass aus der Lagerhalle zu fahren kommen	Information_nachfragen
+GF	Ja ich melde mich gleich kommen	Information_geben
+ZF	Ja das ist verstanden ende	Zusage
+GF	Zugführer von Gruppenführer kommen	Kontakt_Anfrage
+ZF	Hier Zugführer kommen	Kontakt_Bestaetigung
+GF	Zur Information D5 zur Erkundung vor kommen	Information_geben
+ZF	D5 zur Erkundung linker Seite das ist verstanden	Information_geben
+WHS	Zugführer von WHS kommen	Kontakt_Anfrage
+GF	Ja genau ende	Information_geben
+ZF	Hier Zugführer kommen wer hat gerufen kommen	Kontakt_Bestaetigung
+WHS	Zugführer von WHS kommen	Kontakt_Anfrage
+ZF	Ja hier Zugführer kommen	Kontakt_Bestaetigung
+WHS	Panoramabild wurde erstellt kommen	Information_geben
+ZF	Ja das ist verstanden	Information_geben
+ZF	ist das im Lagebildsystem zu erkennen kommen	Information_nachfragen
+WHS	Im Lagebildsystem ist nicht kann es nicht erkannt werden kommen	Absage
+GF	Zugführer von Gruppenführer kommen	Kontakt_Anfrage
+ZF	Hier Zugführer kommen	Kontakt_Bestaetigung
+GF	Frage der D3 soll noch nicht zurückgesetzt werden kommen	Information_nachfragen
+ZF	Ja das ist korrekt	Zusage
+ZF	wir warten noch auf die Verfrachtung des Behälters und danach wird er verschlossen kommen	Information_geben
+GF	Ja verstanden ende	Information_geben
+GF	D5 von Gruppenführer kommen	Kontakt_Anfrage
+GF	falsches Funkgerät	Information_geben
+ZF	Gruppenführer von Zugführer kommen	Kontakt_Anfrage
+GF	Gruppenführer hört	Kontakt_Bestaetigung
+D2	Zugführer von D2 kommen	Kontakt_Anfrage
+ZF	Bitte ich sehe das bild vom D5 im Lagebildsystem bitte einmal die Gasse komplett durch	Einsatzbefehl
+D2	Zugführer von D2 kommen	Kontakt_Anfrage
+GF	Ja verstanden	Zusage
+ZF	Hier Zugführer kommen	Kontakt_Bestaetigung
+D2	D2 hat das Fass in das Überfass abgelegt	Information_geben
+D2	soll das Überfass auch abgedichtet werden kommen	Information_nachfragen
+ZF	Behältniss wurde ins Überfass verfrachtet	Information_geben
+ZF	positiv  das Fass soll geschlossen werden kommen	Zusage
+D2	Verstanden ende	Information_geben
+ZF	D1 von Zugführer kommen	Kontakt_Anfrage
+D1	Hier D1 kommen	Kontakt_Bestaetigung
+ZF	Ja für sie Unterstützung durch Bildübertragung des D2 bei der Fassversiegelung kommen	Einsatzbefehl
+D1	So verstanden ende	Zusage
+WHS	Zugführer von WHS kommen	Kontakt_Anfrage
+ZF	Hier Zugführer kommen	Kontakt_Bestaetigung
+WHS	Die Drohne muss jetzt landen	Information_geben
+WHS	weil der Akku leer ist kommen	Information_geben
+ZF	Schon wieder dann schicken wir doch wieder WHS ins Rennen kommen	Information_geben
+ZF	WHS mitgehört kommen	Information_geben
+WHS	WHS muss landen kommen	Information_geben
+ZF	Ja das ist verstanden	Information_geben
+WHS	Zugführer von WHS kommen	Kontakt_Anfrage
+ZF	Ja hier Zugführer kommen	Kontakt_Bestaetigung
+WHS	Unsere Drohne ist wieder einsatzbereit kommen	Information_geben
+ZF	Ja das ist verstanden	Information_geben
+ZF	für sie noch kein Einsatz der D1 ist noch im Flug im inneren kommen	Information_geben
+WHS	Haben verstanden kommen	Information_geben
+ZF	Gruppenführer von Zugführer kommen	Kontakt_Anfrage
+GF	Gruppenführer hört	Kontakt_Bestaetigung
+ZF	Ja Frage status Erkundungsergebnisse vom D5 kommen	Information_nachfragen
+GF	Ja bleiben sie kurz dran	Sonstiges
+GF	Zugführer von Gruppenführer	Kontakt_Anfrage
+ZF	Hier Zugführer hört	Kontakt_Bestaetigung
+GF	Ja noch keine Auffälligkeiten bei Erkundung durch D5	Information_geben
+ZF	Das ist verstanden	Information_geben
+ZF	dann für sie neuer Erkundungssauftrag in die Halle einfahren und den D2 durch eine Bildübertragung unterstützen kommen	Einsatzbefehl
+GF	Ja den D2 duch eine Bildübertragung unterstützen kommen	Zusage
+ZF	Ja das ist so korrekt	Information_geben
+ZF	für sie noch zur Information der Kanister wurde geborgen das Fass wird nun versiegelt kommen	Information_geben
+GF	Der Gefahrgutbehälter wurde geborgen das Überfass wird verschlossen habe verstanden kommen	Information_geben
+ZF	Ja so korrekt ende	Information_geben
+ZF	D1 von Zugführer kommen	Kontakt_Anfrage
+D1	D1 hört	Kontakt_Bestaetigung
+ZF	Frage wolltet ihr nicht landen kommen	Information_nachfragen
+D1	Wir haben noch 4 Minuten mindestens	Information_geben
+ZF	Ja perfekt für sie zur Information der D5 kommt jetzt auch zur Unterstützung mit Bildübertragung in die Halle kommen	Information_geben
+D1	Alles klar ende	Information_geben
+ZF	D2 für Zugführer kommen	Kontakt_Anfrage
+ZF	D2 für Zugführer kommen	Kontakt_Anfrage
+D2	D2 hört kommen	Kontakt_Bestaetigung
+ZF	Ja für sie zur Information der D5 kommt auch noch zur Unterstützung mittels Bildübertragung in die Halle kommen	Information_geben
+D2	Verstanden ende	Information_geben
+GF	Zugführer von Gruppenführer kommen	Kontakt_Anfrage
+ZF	Zugführer kommen	Kontakt_Bestaetigung
+GF	Ja zur Information der D5 fährt jetzt in die Halle ein um D2 zu unterstützen kommen	Information_geben
+ZF	Ja soweit verstanden	Information_geben
+D2	Zugführer von D2 kommen	Kontakt_Anfrage
+ZF	Hier Zugführer kommen	Kontakt_Bestaetigung
+GF	Zugführer von Gruppenführer kommen	Kontakt_Anfrage
+ZF	Gruppenführer warten sie kurz ende	Sonstiges
+D2	Das Überfass wurde verschlossen kommen	Information_geben
+ZF	Ja hier Zugführer das Überfass wurde versiegelt ist das korrekt kommen	Information_nachfragen
+D2	Das ist korrekt kommen	Zusage
+ZF	Alles klar für sie Rückkehr an den Gefahrenbereich vor die Halle kommen	Einsatzbefehl
+D2	Verstanden kommen	Zusage
+ZF	So korrekt ende	Information_geben
+ZF	Gruppenführer von Zugführer kommen	Kontakt_Anfrage
+GF	Gruppenführer hört	Kontakt_Bestaetigung
+ZF	Sie hatten vorhin Sprechwunsch kommen	Information_nachfragen
+GF	Der D5 hat den Zielort erreicht	Information_geben
+GF	frage ausreichend Bildmaterial zur Unterstützung erhalten kommen	Information_nachfragen
+D1	Zugführer von D1 kommen	Kontakt_Anfrage
+ZF	Das Bild ist super	Information_geben
+ZF	für sie zur Information das Überfass wurde versiegelt und der D2 fährt jetzt an der Gefahrenbereich heran kommen	Information_geben
+GF	Ja verstanden	Information_geben
+ZF	D2 von Zugführer kommen	Kontakt_Anfrage
+D2	D2 hört kommen	Kontakt_Bestaetigung
+ZF	Sofortiger Stop des Roboters	Einsatzbefehl
+ZF	Kontaminationsverschleppung	Information_geben
+ZF	bitte verweilen sie am Gefahrenbereich kommen	Einsatzbefehl
+D2	Verstanden kommen	Zusage
+ZF	Schön wieder zurück	Einsatzbefehl
+ZF	das zeug wollen wir hier nicht draußen haben	Information_geben
+D2	Verstanden kommen	Zusage
+D1	Zugführer von D1 bitte kommen	Kontakt_Anfrage
+ZF	Hier Zugführer kommen	Kontakt_Bestaetigung
+D1	D1 muss landen bitte kommen	Information_geben
+GF	Zugführer von Gruppenführer kommen	Kontakt_Anfrage
+ZF	Ja das ist verstanden	Information_geben
+ZF	auch für sie zur Information der D2 hat seinen Auftrag erledigt	Information_geben
+ZF	für sie auch bitte die Drohne in der Nähe des Gefahrenbereiches an der Grenze absetzen kommen	Einsatzbefehl
+D1	verstanden ende	Zusage
+ZF	hier Zugführer kommen	Kontakt_Bestaetigung
+GF	Ja frage Einsatzbefehl für den D2	Information_nachfragen
+GF	der D2 steht zum Abstransport mit Behälter bereit	Information_geben
+ZF	Korrektur der D3 Fragezeichen kommen	Information_nachfragen
+GF	Ja das ist korrekt der D3 kommen	Zusage
+ZF	Dann Auftag für den D3 das Fass an die Gefahrengrenze bringen	Einsatzbefehl
+GF	Ja das Überfass mit dem D3 an die Gefahrengrenze bringen verstanden	Zusage
+ZF	D2 von Zugführer kommen	Kontakt_Anfrage
+D2	D2 kommen	Kontakt_Bestaetigung
+ZF	Für sie ist der einsatz hier beendet	Einsatzbefehl
+ZF	der roboter wird an den Dekontaminationstrupp übergeben kommen	Information_geben
+D2	Verstanden kommen	Zusage
+GF	Zugführer von Gruppenführer kommen	Kontakt_Anfrage
+ZF	Zugführer hört	Kontakt_Bestaetigung
+GF	Ja der D3 ist jetzt mit Überfass an der Gefahrengrenze kommen	Information_geben
+ZF	Verstanden	Information_geben
+ZF	für sie hier auch Einsatzende	Einsatzbefehl
+GF	Ja verstanden ende	Zusage
+TL	Operator Boden 2 hörst du mich?	Kontakt_Anfrage
+UGV-2	hier spricht der Roboter-Operator 2, ich höre Sie klar und deutlich	Kontakt_Bestaetigung
+TL	Operator Boden 1 für Teamleader, kommen	Kontakt_Anfrage
+UGV-1	ich kann dich klar und deutlich verstehen	Kontakt_Bestaetigung
+TL	großartig	Information_geben
+TL	Mission Commander für Teamleader	Kontakt_Anfrage
+MC	Mission Commander hört	Kontakt_Bestaetigung
+TL	wir sind soweit, Kommunikation klappt	Information_geben
+MC	ja, verstanden	Information_geben
+MC	dann warten wir auf das Startsignal das wird ein Martinhorn sein	Information_geben
+MC	UAV auf Position?	Information_nachfragen
+TL	Teamleader hört	Kontakt_Bestaetigung
+MC	auf dem Gelände hat es eine Explosion gegeben in nem unklaren Raum	Information_geben
+MC	wir haben im Moment Feuer drei gemeldet	Information_geben
+MC	bitte bringen Sie Ihre Gerätschaften in Stellung, in sicherem Bereich innerhalb der großen Halle	Einsatzbefehl
+MC	so, ihr Einsatzauftrag postieren Sie sich innerhalb der großen Halle im sicheren Bereich	Einsatzbefehl
+MC	und melden Sie mir, wenn Sie einsatzbereit sind	Einsatzbefehl
+TL	hier Teamleader, verstanden	Zusage
+TL	Team, auf Position gehen	Einsatzbefehl
+TL	Boden 1 nach rechts	Einsatzbefehl
+UGV-2	ja, ich versuche das rauszufinden	Zusage
+MC	Teamleader für Mission Commander	Kontakt_Anfrage
+TL	hier Teamleader	Kontakt_Bestaetigung
+MC	wenn Sie einsatzbereit sind, lautet der Einsatzauftrag bitte geben Sie mir einen Gesamtüberblick aus der Luft	Einsatzbefehl
+MC	suchen Sie nach möglichen Rauchentwicklungen	Einsatzbefehl
+MC	konzentrieren Sie sich besonders auf den Bereich zwischen den beiden Hochöfen beziehungsweise am linken Hochofen	Einsatzbefehl
+TL	ja, Einsatzauftrag verstanden	Zusage
+TL	Operator Boden 1 fahren Sie nach links	Einsatzbefehl
+UGV-1	Operator Boden 1 hat gehört	Information_geben
+UGV-1	ich fahre nach links	Zusage
+UGV-1	sehe dort schon Rauch- entwicklung	Information_geben
+TL	da ein Foto machen	Einsatzbefehl
+TL	Operator Boden 2 ein Foto senden	Einsatzbefehl
+UGV-2	hier ist Operator Boden 2	Kontakt_Anfrage
+UGV-2	wir können momentan keine Fotos machen	Absage
+TL	hier Teamleader, verstanden	Information_geben
+TL	UAV?	Kontakt_Anfrage
+TL	bitte eine Gesamtübersicht von dem zentralen Gebäude	Einsatzbefehl
+MC	Teamleader von Mission Commander	Kontakt_Anfrage
+TL	Teamleader hört	Kontakt_Bestaetigung
+MC	zu Ihrer Information es werden zwei vermisste Personen gemeldet	Information_geben
+TL	zwei vermisste Personen, verstanden	Information_geben
+TL	Operator Boden 1	Kontakt_Anfrage
+TL	das Bild ist noch nicht angekommen	Information_geben
+UGV-1	Teamleader, hast du jetzt ein Bild?	Information_nachfragen
+TL	negativ	Absage
+UGV-1	ja, es klappt irgendwie nicht	Information_geben
+MC	Teamleader von Mission Commander, kommen	Kontakt_Anfrage
+TL	Teamleader hört	Kontakt_Bestaetigung
+MC	ich hab auf meinem Bildschirm ein Bild der UAV	Information_geben
+MC	können Sie das Bild interpretieren?	Information_nachfragen
+TL	das Bild habe ich auch, ich versuch's gerade größer zu machen	Information_geben
+MC	Teamleader von Mission Commander, kommen	Kontakt_Anfrage
+TL	Teamleader hört	Kontakt_Bestaetigung
+MC	einer der Arbeiter hat zuletzt auf einem höheren Level der Anlage gearbeitet im Bereich des linken Hochofens, ungefähr in 50 Meter Höhe	Information_geben
+TL	hier Teamleader, verstanden	Information_geben
+TL	UAV-Operator für Teamleader, kommen	Kontakt_Anfrage
+UAV	UAV-Operator, ja?	Kontakt_Bestaetigung
+TL	fliegen Sie mit der Drohne über den linken Hochofen oberste Höhe	Einsatzbefehl
+TL	und dann ein Foto senden	Einsatzbefehl
+UAV	okay	Zusage
+TL	Operator Boden 2	Kontakt_Anfrage
+TL	können Sie ein Bild senden?	Information_nachfragen
+UGV-2	hier Operator Boden 2	Kontakt_Bestaetigung
+UGV-2	momentan kann ich keine Bilder senden	Absage
+MC	Teamleader von Mission Commander	Kontakt_Anfrage
+TL	hier Teamleader	Kontakt_Bestaetigung
+MC	auf einem der Fotos sind Rauchentwicklungen zu erkennen	Information_geben
+MC	wie ist der Status Ihrer Bodenroboter, beziehungsweise der Standort?	Information_nachfragen
+MC	ist es möglich, die Quelle der Rauchentwicklung mit dem Bodenroboter zu finden?	Information_nachfragen
+UGV-1	Teamleader zu Bodenoperator 1, kommen	Kontakt_Anfrage
+TL	Bodenoperator 1, sprechen	Kontakt_Bestaetigung
+UGV-1	Leckage entdeckt über Bodenroboter	Information_geben
+TL	sehr gut	Information_geben
+TL	einmal ein Foto machen	Einsatzbefehl
+UGV-1	ich versuch' das mal	Zusage
+UAV	UAV Operator	Kontakt_Anfrage
+UAV	wir haben uns den Hochofen jetzt von oben angeguckt, es ist nirgendwo ein Opfer zu sehen	Information_geben
+TL	ist von oben Verrauchung zu sehen?	Information_nachfragen
+UAV	ja	Zusage
+TL	dann bitte einmal ein Foto davon und wieder landen	Einsatzbefehl
+UAV	okay	Zusage
+TL	Mission Commander für Teamleader	Kontakt_Anfrage
+MC	Mission Commander hört	Kontakt_Bestaetigung
+TL	der Operator Boden 1 hat eine Leckage entdeckt	Information_geben
+TL	das ist auf der ersten Etage, und man könnte von hier unten einen Löscheingriff aufbauen und das Ganze eingrenzen	Information_geben
+MC	ja	Information_geben
+MC	dann überstelle ich Ihnen einen Trupp der sich auf der entgegengesetzten Seite auf der Brücke bereitet	Information_geben
+MC	bitte über Kanal 53WU ansprechen	Einsatzbefehl
+TL	ja, verstanden	Zusage
+UGV-1	Teamleader von Bodenoperator 1	Kontakt_Anfrage
+TL	hier Teamleader	Kontakt_Bestaetigung
+UGV-1	's ist technisch nicht möglich, Bilder zu senden	Information_geben
+TL	ja, verstanden	Information_geben
+MC	Teamleader von Mission Commander, kommen	Kontakt_Anfrage
+TL	Mission Commander für Teamleader	Kontakt_Anfrage
+MC	Mission Commander hört	Kontakt_Bestaetigung
+TL	Sie hatten was?	Information_nachfragen
+MC	ja	Zusage
+MC	gibt es eine Information über die Substanz, die dort austritt?	Information_nachfragen
+TL	ja von Operator Boden 1	Zusage
+TL	Operator Boden 1 für Teamleader, kommen	Kontakt_Anfrage
+UGV-1	Operator Boden 1 hört	Kontakt_Bestaetigung
+TL	was hatten Sie?	Information_nachfragen
+UGV-1	die ausströmende Flüssigkeit ist ein dichter weißlicher Nebel Flüssigkeit unbekannt	Information_geben
+TL	alles klar	Information_geben
+TL	ist es möglich, ein Foto von dem Fass zu machen, was daneben steht?	Information_nachfragen
+UGV-1	weiterhin technisch nicht möglich, Fotos zu senden	Absage
+TL	gut	Information_geben
+TL	Mission Commander für Teamleader, kommen	Kontakt_Anfrage
+MC	Mission Commander hört	Kontakt_Bestaetigung
+TL	ein Trupp ist in der Nähe dort wo auch der Operator Boden 1 seinen Roboter hat und hat dort ein Fass entdeckt in Grün, und ein weiteres Fass mit einer Plakette drauf - ätzend - in Gelb und braucht weitere Unterstützung	Information_geben
+TL	ich fordere weitere Kräfte an	Information_geben
+MC	okay, dann ändern wir Einsatzstichwort auf technische Hilfe ABC	Information_geben
+MC	versuchen Sie mit hilfe der Bodenroboter die Substanzen herauszufinden	Einsatzbefehl
+MC	oder ob es möglich ist, die Leckage abzudichten	Einsatzbefehl
+TL	ja, verstanden	Zusage
+TL	Mission Commander für Teamleader	Kontakt_Anfrage
+MC	Mission Commander hört	Kontakt_Bestaetigung
+TL	draußen steht ein Löschzug mit Blaulicht	Information_geben
+TL	soll ich die mal ansprechen? nicht, dass sie wegen dem Rauch hier stehen	Information_nachfragen
+MC	ja, auf jeden Fall, mach das mal	Zusage
+TL	alles klar	Information_geben
+TL	es kommt jetzt hier ein Gruppenführer	Information_geben
+TL	Übungende	Einsatzbefehl
+TL	für alle: Übungende	Einsatzbefehl
+UAV	okay	Zusage
+UGV-2	okay	Zusage
+TL	Bodenoperator für Teamleader kommen	Kontakt_Anfrage
+TL	Bodenoperator 1 für Teamleader	Kontakt_Anfrage
+UGV-1	Bodenoperator 1 hört	Kontakt_Bestaetigung
+TL	wir können jetzt gleich starten, die Drohne ist bereit	Information_geben
+TL	Bodenoperator 2 für Teamleader, kommen	Kontakt_Anfrage
+TL	Bodenoperator 2 für Teamleader, kommen	Kontakt_Anfrage
+UGV-2	hier Bodenoperator 2	Kontakt_Bestaetigung
+TL	Verständigung einwandfrei	Information_nachfragen
+UGV-2	ja, ich verstehe Sie	Zusage
+TL	gut	Information_geben
+TL	Drohnenoperator für Teamleader, kommen	Kontakt_Anfrage
+TL	Drohnenoperator für Teamleader, kommen	Kontakt_Anfrage
+TL	Drohnenoperator für Team-Operator, kommen	Kontakt_Anfrage
+UGV-2	hier Robot-Operator 2	Kontakt_Anfrage
+TL	Verständigung war einwandfrei?	Information_nachfragen
+UGV-2	ja, ich verstehe Sie einwandfrei	Zusage
+UAV	UAV-Operator	Kontakt_Bestaetigung
+UAV	wir sind einsatzbereit	Information_geben
+UAV	UAV operator für team leader	Kontakt_Anfrage
+UAV	sollen wir starten mit der UAV und einen Überblick verschaffen?	Information_nachfragen
+TL	ja	Zusage
+TL	Drohnenoperator, starten Sie und machen Sie sich einen Überblick über die Lage	Einsatzbefehl
+TL	über- machen	Sonstiges
+TL	wir vermissen Personen und eine unklare Sache in der ganzen Area	Information_geben
+UAV	okay	Zusage
+TL	Bodenoperator für Teamleader, kommen	Kontakt_Anfrage
+UGV-2	hier Bodenoperator 2	Kontakt_Bestaetigung
+TL	starten Sie Ihre Roboter zur Erkundung der Area	Einsatzbefehl
+TL	ist eine unklare Sache, wir wissen noch nicht genau, was da passiert ist	Information_geben
+TL	Personen sind vermisst	Information_geben
+UGV-2	starten die Suche mit Roboter 2 jetzt	Zusage
+TL	Bodenoperator 1 für Teamleader, kommen	Kontakt_Anfrage
+UGV-1	Bodenoperator 1 hat mitgehört und startet ebenfalls	Kontakt_Bestaetigung
+UAV	UAV-Operator an Teamleader	Kontakt_Anfrage
+UAV	ich habe ein Bild veröffentlicht	Information_geben
+UAV	was zeigte, dass keine Rauchentwicklung gibt über der Anlage	Information_geben
+TL	ja, Teamleader hat mitgehört	Information_geben
+TL	aber so leichte Rauchentwicklung ist jetzt zu sehen	Information_geben
+TL	mehr Richtung Hochofen einmal schauen	Einsatzbefehl
+UAV	okay	Zusage
+UGV-1	Teamleader von Bodenoperator 1	Kontakt_Anfrage
+TL	Teamleader hört	Kontakt_Bestaetigung
+UGV-1	ich bin am Ende der ersten Rampe, hab in beiden Richtungen geguckt	Information_geben
+UGV-1	in keiner Richtung was Auffälliges	Information_geben
+UGV-1	soll ich rechts oder links rum?	Information_nachfragen
+TL	Position beibehalten	Information_geben
+TL	wir versuchen weitere Informationen zu bekommen	Information_geben
+TL	Drohnenoperator für Teamleader, kommen	Kontakt_Anfrage
+UAV	hier Drohnenoperator	Kontakt_Bestaetigung
+TL	ist bei euch was zu sehen?	Information_nachfragen
+UAV	wir mussten gerade die Applikation nochmal neu starten	Information_geben
+UAV	ich hab Bilder freigegeben, wir versuchen sie gerade sichtbar zu machen	Information_geben
+TL	auf meinem Tablet ist nix zu sehen	Information_geben
+UAV	okay	Information_geben
+UAV	ein paar Sekunden noch	Information_geben
+TL	Bodenoperator 1 für Teamleader, kommen	Kontakt_Anfrage
+UGV-1	hier Bodenoperator 1	Kontakt_Bestaetigung
+TL	da ich eine leichte Rauchentwicklung auf der linken Seite sehe, bitte den Weg zur linken Seite fortsetzen	Einsatzbefehl
+UGV-1	nach links, verstanden	Zusage
+TL	Bodenoperator 1 für Teamleader, kommen	Kontakt_Anfrage
+UGV-1	hier Bodenoperator 1	Kontakt_Bestaetigung
+TL	fährst du die falsche Richtung?	Information_nachfragen
+UGV-1	Teamleader für Bodenoperator 1	Kontakt_Anfrage
+TL	Teamleader hört	Kontakt_Bestaetigung
+UGV-1	voraus ist 'ne Treppe und da drüber relativ dichter Rauch zu sehen	Information_geben
+UGV-1	soll ich ein Foto machen?	Information_geben
+TL	ja, wenn's geht	Zusage
+TL	näher ranfahren zum Lokalisieren, wo dieser Rauch entsteht, und Foto machen und mir senden	Einsatzbefehl
+TL	aber ich kann immer noch nichts empfangen	Information_geben
+UAV	Teamleader für UAV bereit da?	Kontakt_Anfrage
+TL	Teamleader hört	Kontakt_Bestaetigung
+TL	die Bilder habe ich jetzt bekommen	Information_geben
+UAV	alles klar	Information_geben
+UAV	man kann von oben sehen, dass der Rauch aus dem Gebäude austritt	Information_geben
+TL	das habe ich auch gesehen	Information_geben
+TL	ich schick da erst mal ein Trupp ein	Information_geben
+UGV-2	Teamleader für Robot-Operator 2	Kontakt_Anfrage
+TL	ja, Teamleader hört	Kontakt_Bestaetigung
+UGV-2	wir haben leider Probleme mit dem Joystick und sitzen noch an der Startposition fest	Information_geben
+UGV-2	wir versuchen, das jetzt zu beheben	Information_geben
+TL	wenn ihr ja weiter einsatzbereit seid, dann bitte melden	Einsatzbefehl
+UGV-2	machen wir	Zusage
+UGV-1	Teamleader für Bodenoperator 1	Kontakt_Anfrage
+UGV-1	Teamleader für Bodenoperator 1	Kontakt_Anfrage
+TL	Teamleader hört	Kontakt_Bestaetigung
+UGV-1	vor mir ist ein grünes Fass und da obendrauf steht noch ein gelbes und ich habe Personen in dem Rauch gesehen	Information_geben
+UGV-1	der Rauch kommt von rechts	Information_geben
+TL	verstanden	Information_geben
+UGV-1	ich versuche, von dem Fass ein gutes Foto zu machen	Information_geben
+TL	okay	Zusage
+UGV-1	Teamleader für Bodenroboter 1	Kontakt_Anfrage
+TL	Teamleader hört	Kontakt_Bestaetigung
+UGV-1	Bodenoperator 1 hat die Leckage gefunden an einem Stromerzeuger	Information_geben
+UGV-1	Foto wurde gesendet	Information_geben
+UGV-1	hast du denn es empfangen?	Information_nachfragen
+UGV-1	Teamleader für Bodenoperator 1	Kontakt_Anfrage
+TL	Teamleader hört	Kontakt_Bestaetigung
+UGV-1	eine Person gesichtet	Information_geben
+UGV-1	ist in der Nähe von dem Fass und von der Leckage, wo der Rauch austritt	Information_geben
+UGV-1	Foto habe ich dir geschickt	Information_geben
+TL	versta- Mission	Sonstiges
+TL	Mission Operator für Teamleader, kommen	Kontakt_Anfrage
+UAV	Teamleader für UAV-Operator	Kontakt_Anfrage
+UAV	Teamleader für UAV-Operator	Kontakt_Anfrage
+TL	Teamleiter kann hören	Kontakt_Bestaetigung
+UAV	wir haben ein Opfer gefunden, liegt auf liegt auf der hinteren Seite des Hochofens angelehnt, scheint bewusstlos zu sein	Information_geben
+TL	ja, ich schick mal ein Trupp hin	Information_geben
+UAV	da ist keine Rauchentwicklung	Information_geben
+TL	okay, ich schick ein Trupp hin	Information_geben
+UGV-1	Teamleader für Bodenoperator 1	Kontakt_Anfrage
+UGV-1	hab Sie nicht verstanden	Information_geben
+TL	ich kann nur noch kommunizieren, ich kann keine Bilder empfangen, oder auch senden	Information_geben
+TL	kommen	Kontakt_Anfrage
+UGV-2	Teamleader für Bodenoperator 2, kommen	Kontakt_Anfrage
+TL	Teamleader hört	Kontakt_Bestaetigung
+UGV-2	wir haben das Problem behoben, mit der Fernsteuerung, und machen uns auf auf den Weg hinein	Information_geben
+TL	wie gesagt, ich kann keine Bilder empfangen	Information_geben
+UGV-1	Teamleader für Bodenoperator 1	Kontakt_Anfrage
+TL	Teamleader hört	Kontakt_Bestaetigung
+UGV-1	eine Person gesichtet, ist auf der Ebene, auf der auch die Leckage ist, hinter dem ersten Hochofen	Information_geben
+UGV-1	halb liegend	Information_geben
+TL	verstanden	Information_geben
+TL	UGV-1 von Teamleader Leiter	Kontakt_Anfrage
+TL	UGV-1 von Teamleiter	Kontakt_Anfrage
+TL	Nicht gerade	Sonstiges
+TL	UGV-2 von Teamleiter	Kontakt_Anfrage
+UGV-2	UGV-2 hört	Kontakt_Bestaetigung
+TL	Für Sie kurze Lageinformation es gab einen Unglücksfall in dem länglichen Graphecs Gebäude Luftbildaufnahmen sagen dass es unstabil und unsicher für Personen ist	Information_geben
+TL	Unsere Aufgabe erstellen einer Karte des Gebäudes	Information_geben
+UGV-2	Erstellen einer Lage einer Karte des länglichen Gebäudes verstanden	Information_geben
+TL	Für Sie konkreter Auftrag Sie begeben sich zur nördlichen Gebäudekante und bewegen sich dann westwärts	Einsatzbefehl
+TL	Das ist so korrekt	Information_geben
+TL	UGV-1 von Teamleiter	Kontakt_Anfrage
+UAV	Teamleader von UAV operator kommen	Kontakt_Anfrage
+TL	Teamleader	Kontakt_Bestaetigung
+UAV	Ja die 3D Karte ist in Arbeit Dauer für das Modell circa halbe Stunde	Information_geben
+UAV	in der Ar- in Arbeit	Sonstiges
+UAV	komme wieder wenn Aufgabe beendet	Information_geben
+TL	Das ist verstanden	Zusage
+TL	UGV-1 von Teamleiter	Kontakt_Anfrage
+UGV-1	Hier ist UGV-1	Kontakt_Bestaetigung
+TL	Frage Standort	Information_nachfragen
+UGV-2	Teamleiter von UGV-2	Kontakt_Anfrage
+TL	Teamleiter	Kontakt_Bestaetigung
+UGV-2	Ich hab mal ein Foto gemacht	Information_geben
+UGV-2	das ist die Wand meines Erachtens in nördlicher Feuerlöscheinrichtung und Lagerteile an den Wänden der Regalen	Information_geben
+TL	Bis jetzt ist das Foto noch nicht angekommen	Information_geben
+TL	haben Sie auf Teilen geklickt?	Information_nachfragen
+TL	UGV-1 von Teamleiter	Kontakt_Anfrage
+UGV-1	Hier ist UGV-1	Kontakt_Bestaetigung
+TL	Frage Ihr Standort immer noch mittig in der Halle oder inzwischen weiter in Richtung Westen	Information_nachfragen
+UGV-1	Ja ist mittig in der Halle	Information_geben
+UGV-1	Ich habe hier eine Erkenntniss hier ist ein Feuerlöscher fehlt	Information_geben
+UGV-1	Bild kommt	Information_geben
+TL	Das ist verstanden	Zusage
+TL	UGV-1 von Teamleiter	Kontakt_Anfrage
+UGV-1	Hier ist UGV-1	Kontakt_Bestaetigung
+TL	Teilen Sie mir bitte auch mal ein Foto in ihrer Fahrtrichtung	Einsatzbefehl
+UGV-1	Ja kommt	Zusage
+TL	UGV-2 von Teamleiter	Kontakt_Anfrage
+UGV-2	Direction is correct	Information_geben
+TL	UGV-1 von Teamleiter	Kontakt_Anfrage
+UGV-1	Hier ist UGV-1	Kontakt_Bestaetigung
+TL	Haben Sie das Foto bereits geteilt?	Information_nachfragen
+UGV-1	Bild müsste da sein ja	Zusage
+TL	Ja hier ist mal nichts	Information_geben
+TL	dann liegt's an mir	Information_geben
+UGV-1	Dann mag es so sein	Information_geben
+TL	UGV-2 von Teamleiter	Kontakt_Anfrage
+UGV-2	Hier UGV-2	Kontakt_Bestaetigung
+TL	Haben Sie irgendwelche Anzeichen von Gebäudeschäden gefunden?	Information_nachfragen
+UGV-2	Bisschen rissige Säulen aber es wird halten Überdimensionierung	Information_geben
+TL	Ja das ist verstanden	Information_geben
+TL	UGV-1 von Teamleiter	Kontakt_Anfrage
+TL	UAV operator von Teamleiter	Kontakt_Anfrage
+UAV	Hier UAV operator	Kontakt_Bestaetigung
+TL	Für sie Auftrag innerhalb des Gebäudes nach Hitze- und Rauchquellen suchen	Einsatzbefehl
+TL	Sollten dabei Verletzte oder chemische Substanzen gesichtet werden ebenfalls bitte melden und auf der Karte markieren	Einsatzbefehl
+UAV	Ja zur Erkundung von Rauchquellen Personen	Zusage
+UAV	Vor zur Information und Protektion oberhalb	Information_geben
+TL	Ja das ist verstanden	Information_geben
+TL	Sie kommt sehr leise über Funk	Information_geben
+UAV	Ja	Information_geben
+TL	Jetzt hör ich dich besser	Information_geben
+TL	UGV-2 von Teamleiter	Kontakt_Anfrage
+UGV-2	Hier UGV-2	Kontakt_Bestaetigung
+TL	Für Sie Auftrag Sie sind mit Messgeräten zur Gasmessung ausgestattet alle 15 Minuten die Gaskonzentration messen	Einsatzbefehl
+TL	Und desweiteren erkunden Sie die südliche Gebäudewand von ihrem Standort aus in westlicher Richtung	Einsatzbefehl
+UGV-2	Südliche Gebäudewand in westlicher Richtung kontrollieren	Zusage
+UGV-2	Und alle 15 Minuten Gasdetektoren einschalten verstanden	Zusage
+UGV-2	Zur Info ich hab keinen Kontakt zu meinem Roboter	Information_geben
+TL	Ja das ist erst mal verstanden	Information_geben
+UGV-1	Hier ist UGV-1	Kontakt_Anfrage
+TL	Sie suchen die nördliche Gebäudewand in westlicher Richtung ab	Einsatzbefehl
+TL	In erster Linie suchen wir nach Verletzten	Einsatzbefehl
+TL	Aber auch Hitzequellen Rauchquellen oder chemische Substanzen melden und auf der Karte markieren	Einsatzbefehl
+UGV-1	Gebäude nördliche Wand in westlicher Richtung absuchen nach Hitzequellen und vermissten Personen verstanden	Zusage
+TL	Ja ebenfalls auf Chemikalien achten Trader Fluorid und Trader Oxin müssten auch irgendwo sein	Einsatzbefehl
+UGV-1	Ja das ist okay ist verstanden	Zusage
+UAV	Teamleader von UAV operator kommen	Kontakt_Anfrage
+TL	Teamleiter	Kontakt_Bestaetigung
+UAV	Hier ist ein recht guter Überblick	Information_geben
+UAV	kommen	Kontakt_Anfrage
+UAV	von der Halle vielleicht hilft das zu	Information_geben
+TL	Ich kann Sie nicht aufnehmen	Information_geben
+TL	wiederholen	Einsatzbefehl
+UAV	Ja ich hab dir ein Bild geteilt mit einem recht guten Überblick über die Gebäudestruktur und die Halle	Information_geben
+UAV	vielleicht hilft es zu	Information_geben
+TL	Ich gucke mir erst mal an	Information_geben
+TL	Verbindung ist aber immer noch sehr schlecht	Information_geben
+UAV	Teamleader von UAV operator kommen	Kontakt_Anfrage
+TL	Teamleader	Kontakt_Bestaetigung
+UAV	Zur Information eine Person im oberen Gebäudeteil identifiziert und ein Chemikalienfass	Information_geben
+TL	UAV operator von Teamleader	Kontakt_Anfrage
+UAV	UAV operator	Kontakt_Bestaetigung
+TL	Habt ihr den Standort geteilt?	Information_nachfragen
+UAV	Ich hab weiter	Information_geben
+TL	UAV operator von Teamleader	Kontakt_Anfrage
+UAV	Hier UAV operator	Kontakt_Bestaetigung
+TL	Habt ihr neuen Status zum Standort der Person oder der Chemikalien?	Information_nachfragen
+TL	Ich krieg keinen Standort	Information_geben
+UAV	Ja ich habe da ich keine GPS Daten	Information_geben
+UAV	Muss ich kurz identifizieren wo ich bin ich versuche mich mal zu orientieren	Information_geben
+TL	UGV-1 von Teamleader	Kontakt_Anfrage
+UGV-1	Vom Startpunkt entfernt	Information_geben
+TL	Na ja das ist verstanden	Information_geben
+TL	Sehen Sie den Victim der durch die Drohne eingegeben wurde?	Information_nachfragen
+TL	Auf eurem TDS müsste mittig der Halle eine Person eingetragen worden sein	Information_geben
+UGV-1	Viel zu weit entfernt	Information_geben
+TL	Ja das ist verstanden	Information_geben
+TL	Wenn Sie sich an der nördlichen Gebäudewand entlang nach Westen bewegen nehmen sie immer so den Victim als Ziel	Einsatzbefehl
+UGV-1	Ja die nördliche Wand kann ich gar nicht erreichen	Absage
+UGV-1	ich kann höchstens den UGV-2 folgen	Information_geben
+TL	Der UGV-2 geht zur südlichen Gebäudewand das ist Ihnen bekannt	Information_geben
+UGV-1	Das ist mir bekannt	Information_geben
+UGV-1	Aber die nördliche Wand besaß kein Zugang	Information_geben
+UGV-1	Kannst du uns zur nördlichen Gebäudewand?	Information_nachfragen
+TL	Das ist verstanden	Information_geben
+TL	dann folgen Sie den UGV-2	Einsatzbefehl
+UAV	Teamleader von UAV operator kommen	Kontakt_Anfrage
+TL	Teamleader	Kontakt_Bestaetigung
+UAV	Ja ich hab dir die vermutliche Position die mögliche Position vom Opfer und dem Chemikalienfass geschickt	Information_geben
+UAV	Weiter kann ich die Aufschrift des Chemikalienfasses nicht identifizieren	Information_geben
+UAV	da die verletzte Person im Weg sitzt	Information_geben
+UAV	Über dem Zustand der Person keine weiteren Erkenntnisse zu bekommen	Information_geben
+TL	Sven, kommen	Kontakt_Anfrage
+TL	Lena für Benno, kommen	Kontakt_Anfrage
+UGV-1	ja, der Operator 1 hört	Kontakt_Bestaetigung
+UGV-2	der Operator 2 hört	Kontakt_Bestaetigung
+UAV	UAV Operator hört	Kontakt_Bestaetigung
+TL	ja, folgende Lage: im Bereich zwischen den Hochöfen hat es eine Explosion gegeben	Information_geben
+TL	Ursache ist unbekannt Rauchentwicklung, vermutlich auch Feuer, mehrere vermisste Personen, Anzahl der vermissten Personen ist ebenfalls unbekannt	Information_geben
+TL	unsere Aufgabe ist es halt Menschenrettung	Information_geben
+TL	Frage zunächst, wer hat den Roboter mit dem Arm?	Information_nachfragen
+UGV-2	ja, das ist der Sven, Operator 2	Information_geben
+TL	ja, hab ich verstanden	Information_geben
+TL	Sven, Tom und Lena zur Kenntnis: der Angriffstrupp geht unter Atemschutz im Bereich zwischen den Hochöfen vor und erkundet zunächst	Information_geben
+UGV-1	ja, ist verstanden	Information_geben
+UGV-2	ja, Operator 2 hat verstanden	Information_geben
+UAV	UAV Operator, verstanden	Information_geben
+TL	so, UAV one über den Benno kommen	Kontakt_Anfrage
+UAV	UAV Operator hört	Kontakt_Bestaetigung
+TL	ja, ich hätte gerne dass du mit dem Vogel da einmal über die Hochöfen fliegst, nen Rundflug machstguckst, ob du da irgendwelche Personen entdecken kannst	Einsatzbefehl
+TL	von oben uns Fotos machst und guckst, wo wir 'ne Rauchentwicklung haben und auch mit der Infrarot-Kamera	Einsatzbefehl
+UAV	ja, das habe ich verstanden	Zusage
+TL	Operator 2 für Benno, kommen	Kontakt_Anfrage
+UGV-2	ja, Operator 2 hört, Benno	Kontakt_Bestaetigung
+TL	du hast den Roboter mit der Infrarot-Kamera, ist das richtig?	Information_nachfragen
+UGV-2	negativ, ich hab den Roboter mit dem Arm, dort ist keine Infrarot-Kamera vorne	Absage
+TL	verstanden	Information_geben
+TL	Operator 1 für Benno, kommen	Kontakt_Anfrage
+UGV-1	ja, der Operator 1 hört	Kontakt_Bestaetigung
+TL	Auftrag für dich geradeaus die Treppe hochfahren, 50 meter rein, linksseitig dichte Rauchentwicklung	Einsatzbefehl
+TL	dort mit dem Roboter hinfahren und mit der Menschensuche beginnen	Einsatzbefehl
+UGV-1	ja, 50 meter geradeaus, links rein und erkunde nach Menschen	Zusage
+TL	das ist korrekt	Information_geben
+TL	Operator 1 für Benno	Kontakt_Anfrage
+UGV-1	hier der Operator 1	Kontakt_Bestaetigung
+TL	mach mal bitte an den relevanten Punkten Fotos, dass wir den hinterher nachvollziehen können	Einsatzbefehl
+UGV-1	ja, ist verstanden, ich mach hier Fotos	Zusage
+UAV	Benno für UAV Operator	Kontakt_Anfrage
+TL	Augenblick	Sonstiges
+UGV-1	der Teamleader von Operator 1, kommen	Kontakt_Anfrage
+TL	UAV 1, kommen	Kontakt_Bestaetigung
+UGV-1	ja, ich hab gerade ein Foto geschossen, hier sind zwei Treppen auf der linken Seite, allerdings kein Angriffstrupp	Information_geben
+UGV-1	Rauchentwicklung weiter rechts	Information_geben
+UGV-1	Frage: zur Rauchentwicklung vorfahren?	Information_nachfragen
+TL	Augenblick	Sonstiges
+TL	Operator 1 für Teamleiter, kommen	Kontakt_Anfrage
+UGV-1	ja, hier Operator 1	Kontakt_Bestaetigung
+TL	der Angriffstrupp steht an der Rauchentwicklung	Information_geben
+TL	du sollst zur Rauchentwicklung fahren	Einsatzbefehl
+UGV-1	ja, ich fahr zur Rauchentwicklung	Zusage
+TL	UAV Operator für Teamleader, kommen	Kontakt_Anfrage
+TL	Lena für Benno?	Kontakt_Anfrage
+UAV	Lena hört	Kontakt_Bestaetigung
+TL	du hattest mich angesprochen?	Information_nachfragen
+UAV	ja, ich hätte jetzt einmal ein Luftbild von oben, einmal eins zu Übersicht, das schicke ich dir jetzt	Information_geben
+TL	verstanden	Information_geben
+TL	Operator 1, schickst du mir die Bilder auch einmal rüber, die du gemacht hast?	Einsatzbefehl
+UGV-1	ja, das erste Bild hab ich dir gerade schon gesch-	Information_geben
+TL	Operator 1, schickst du mir das nochmal rüber	Einsatzbefehl
+TL	ich habe nichts gekriegt hier	Information_geben
+UGV-1	ja, ich schicke	Zusage
+UGV-1	Teamleader vom Operator 1	Kontakt_Anfrage
+TL	ich höre	Kontakt_Bestaetigung
+UGV-1	das Bild müsstest du schon haben	Information_geben
+TL	ja, verstanden	Information_geben
+TL	hab kein Bild	Information_geben
+UAV	Teamleiter 1 für UAV Operator	Kontakt_Anfrage
+TL	Operator 1 für Teamleader, kommen	Kontakt_Anfrage
+UGV-1	hier Operator 1	Kontakt_Bestaetigung
+TL	Frage: Standort Roboter?	Information_nachfragen
+UGV-1	ist gerade die erste Treppe nach oben gefahren zur Rauchentwicklung, ich erkunde dort im ersten Raum	Information_geben
+TL	die linke Treppe oder die rechte Treppe auf dein'm Foto?	Information_nachfragen
+UGV-1	die rechte Treppe, wo die Rauchentwicklung zu sehen war	Information_geben
+TL	das heißt, du bist da rechts abgebogen, in den Raum rein, richtig?	Information_nachfragen
+UGV-1	das ist richtig	Zusage
+UGV-1	und da bin ich gerade am Anfangen	Information_geben
+TL	ja - Auftrag war, sich mit dem Angriffstrupp zu treffen, zunächst	Information_geben
+UGV-1	ja, Angriffstrupp war nicht vor Ort	Information_geben
+TL	ja, dann möchte ich dort eine Meldung haben	Einsatzbefehl
+TL	dann kümmere ich mich darum	Information_geben
+TL	Augenblick	Sonstiges
+TL	UAV Operator für Teamleader, kommen	Kontakt_Anfrage
+UAV	UAV Operator hört	Kontakt_Bestaetigung
+TL	du hattest mich gerufen?	Information_nachfragen
+UAV	ja	Zusage
+UAV	wir haben einmal den Akku gewechselt, bis jetzt noch kein Rauch festzustellen, aber wir haben eine Person gefunden	Information_geben
+UAV	ich schick dir jetzt das Foto	Information_geben
+TL	ja	Zusage
+TL	Könnten -	Sonstiges
+TL	darauf kann ich sehen, wo der Standort ist?	Information_nachfragen
+UAV	müsste zu erkennen sein	Zusage
+UAV	ja, verstanden	Information_geben
+UGV-1	der Teamleadaer von Operator 1, kommen	Kontakt_Anfrage
+TL	ich höre	Kontakt_Bestaetigung
+UGV-1	also - ich bin jetzt oben im ersten Raum, auch hier ist der Angriffstrupp nicht vorzufinden	Information_geben
+UGV-1	Frage: Raum weiter erkunden?	Information_nachfragen
+TL	ja, richtig	Zusage
+TL	der Angriffstrupp musste raus	Information_geben
+TL	der hatt' keine Luft mehr, den Raum weiter erkunden	Information_geben
+UGV-1	ja, ist verstanden	Information_geben
+TL	Lena für Benno	Kontakt_Anfrage
+UAV	Lena hört	Kontakt_Bestaetigung
+TL	Lena, jetzt sag mir mal genau den Standort dieser Person	Information_nachfragen
+UAV	ich schick dir eben noch zwei andere Fotos, da müsstest du es besser erkennen	Information_geben
+UAV	das ist könnte aber eventuell eine andere Person sein	Information_geben
+TL	ja, habe verstanden	Information_geben
+UAV	Benno für Lena	Kontakt_Anfrage
+TL	ich höre	Kontakt_Bestaetigung
+UAV	ich habe jetzt bei der zweiten Person auch eventuell Rauch gefunden	Information_geben
+TL	du hast mir jetzt ein weiteres Foto geschickt, ist das richtig?	Information_nachfragen
+UAV	ich habe drei geschickt	Zusage
+UAV	Benno für Lena	Kontakt_Anfrage
+TL	Operator 2 für Teamleader, kommen	Kontakt_Anfrage
+UGV-2	Operator 2 hört	Kontakt_Bestaetigung
+TL	folgenden Auftrag: den gleichen Weg nehmen wie Operator 1	Einsatzbefehl
+TL	Auftrag ist: Erkundung nach weiteren Zugangsmöglichkeiten, nach Verletzten	Einsatzbefehl
+TL	schau auch mal wie weit die Rauchentwicklung da ausgedehnt ist	Einsatzbefehl
+UGV-2	ja, ist soweit verstanden	Zusage
+UGV-1	der Teamleader von Operator 1	Kontakt_Anfrage
+TL	ich höre	Kontakt_Bestaetigung
+UGV-1	im ersten großen Raum eine Person gefunden	Information_geben
+TL	prima	Information_geben
+TL	ich schick dir den Angriffstrupp	Information_geben
+TL	Operator 1, der Angriffstrupp ist unterwegs	Information_geben
+TL	rechte Treppe hoch, rechts in den Raum rein, korrekt?	Information_nachfragen
+UGV-1	ja, richtig so	Zusage
+TL	verstanden	Information_geben
+UAV	Benno für Lena	Kontakt_Anfrage
+TL	höre	Kontakt_Bestaetigung
+UAV	ich habe Rauch gefunden, und weitere Personen	Information_geben
+UAV	schi-	Sonstiges
+UAV	ich versuch, dir nochmal die Bilder zu schicken	Information_geben
+TL	ja, verstanden	Information_geben
+TL	bin - ich – k-	Sonstiges
+TL	kann da noch nichts lokalisieren, auch anhand der großen Karte, wo genau diese Personen sich befinden	Information_geben
+UAV	ja, das habe ich verstanden	Information_geben
+TL	Operator 1 für Teamleader, kommen	Kontakt_Anfrage
+UGV-1	ja, ich höre dich	Kontakt_Bestaetigung
+TL	hast du von der Person ein Foto gemacht und mir geschickt?	Information_nachfragen
+TL	Fo-	Sonstiges
+UGV-1	ja, Foto gemacht habe ich	Zusage
+UGV-1	ich weiß bloß nicht, ob es angekommen ist	Information_geben
+TL	ist das der Mensch, der da an einem Pfeiler hockt?	Information_nachfragen
+UGV-1	ganz genau	Zusage
+TL	phantastisch	Information_geben
+UAV	Benno für Lena	Kontakt_Anfrage
+TL	ich höre, Lena	Kontakt_Bestaetigung
+UAV	also - die Person müsste hinter dem großen Hochofen auf dem freien Weg sein	Information_geben
+UAV	der Akku ist jetzt leer	Information_geben
+UAV	wir müssen jetzt auch landen, und warten am Boden auf weitere Anweisungen	Information_geben
+TL	ja, verstanden	Information_geben
+TL	ist das welcher Hochofen ist es, der rechte oder der linke von uns aus gesehen?	Information_nachfragen
+UAV	der eine ist nur das Gerüst und der andere ist voll, ich meine den vollen	Information_geben
+TL	ist das der, der von dir weiter entfernt ist?	Information_nachfragen
+UAV	ja, das ist richtig	Zusage
+TL	hab ich verstanden	Information_geben
+TL	neuer Auftrag ist: Akku tauschen, damit die Drohne wieder fliegen kann	Einsatzbefehl
+UAV	ja, das habe ich verstanden	Zusage
+UGV-1	der Teamleader von Operator 1, kommen	Kontakt_Anfrage
+TL	ich höre	Kontakt_Bestaetigung
+UGV-1	ja, Frage: soll ich nach weiteren Personen suchen?	Information_nachfragen
+TL	ja, klar	Zusage
+TL	einen Augenblick, ich melde mich gleich	Sonstiges
+TL	erst muss der Angriffstrupp da gewesen sein	Information_geben
+UGV-1	ja, verstanden	Information_geben
+UAV	Benno für Lena	Kontakt_Anfrage
+UAV	wir sind jetzt wieder startklar	Information_geben
+TL	Lena, sag nochmal die letzte Meldung, hab ich nicht mitgekriegt	Information_nachfragen
+UAV	wir sind jetzt wieder startklar	Information_geben
+UAV	neuer Akku ist bereit	Information_geben
+TL	ja	Information_geben
+TL	ich melde mich sofort	Information_geben
+TL	Operator 1 für Teamleader, kommen	Kontakt_Anfrage
+UGV-1	hier Operator 1	Kontakt_Bestaetigung
+TL	der Raum ist vollständig abgesucht?	Information_nachfragen
+UGV-1	bis zum Opfer auf jeden Fall	Zusage
+TL	gibt es noch mehr Raum, der noch nicht abgesucht ist?	Information_nachfragen
+UGV-1	ja	Zusage
+UGV-1	der Bereich hinter dem Pfeiler, also hinter dem Teil, wo die Person war	Information_geben
+TL	jo	Information_geben
+TL	dann bitte weiter suchen	Einsatzbefehl
+UGV-1	ja, ist verstanden	Zusage
+TL	Operator 2 für Teamleader, kommen	Kontakt_Anfrage
+TL	Operator 2 für Teamleader, kommen	Kontakt_Anfrage
+UGV-2	ja, hört	Kontakt_Bestaetigung
+TL	wo bist du jetzt? Standort	Information_nachfragen
+TL	mach mal Fotos auch	Einsatzbefehl
+TL	wenn du was findest, dass man den Weg nachvollziehen kann	Information_geben
+UGV-2	ja, mach ich	Zusage
+UGV-2	ich bin gerade dabei, einfach schon mal Richtung den Weg zu kommen, wo der Operator 1 lang gefahren ist	Information_geben
+TL	ja	Information_geben
+TL	dein Auftrag ist, an diesem Raum vorbei, wo der Operator 1 drin ist, und da ab da weiter zu suchen nach Menschen	Einsatzbefehl
+UGV-2	ja	Zusage
+UGV-2	und das Fass, hast du gesagt, da soll ich dran vorbei fahren, ne?	Information_nachfragen
+TL	ja, korrekt	Zusage
+TL	das Fass, das steht dort irgendwo, das war nur zur Orientierung	Information_geben
+TL	aber mach mir mal ein Foto von dem Fass	Einsatzbefehl
+UGV-2	ja, mache ich	Zusage
+TL	Lena für Benno, kommen	Kontakt_Anfrage
+UAV	Lena hört	Kontakt_Bestaetigung
+TL	Lena, du hast alle Fotos jetzt von einer Stelle aus gemacht	Information_geben
+TL	ich möchte mal, dass du mit der Drohne jetzt weiter fliegst zum anderen Hochofen, quasi von der anderen Seite der Einsatzstelle aus Fotos machst	Einsatzbefehl
+TL	mit der - mit der Drohne	Sonstiges
+TL	und guckst, ob du von dort aus noch Personen erkennen kannst	Einsatzbefehl
+UAV	das habe ich verstanden	Zusage
+TL	Operator 2, wie ist dein Standort?	Information_nachfragen
+UGV-2	wir haben gerade ein kleines technisches Problem	Information_geben
+UGV-2	ich melde mich gleich	Information_geben
+TL	verstanden	Information_geben
+UAV	Benno für Lena	Kontakt_Anfrage
+UAV	Benno für Lena	Kontakt_Anfrage
+TL	ich höre	Kontakt_Bestaetigung
+UAV	ich hab dir gerade ein Übersichtsbild geschickt, da erkennt man den gefüllten - also den großen Hochofen sag mir, wo du hinmöchtest	Information_geben
+TL	dass du dieses Bild nochmal machst, aber reinzoomst	Einsatzbefehl
+UAV	wo soll ich reinzoomen, in den - eher in den Hochofen oder genau in die Mitte?	Information_nachfragen
+TL	das gleiche Bild, was du jetzt gemacht hast, da in die Mitte reinzoomen, da wo die Rauchentwicklung ist	Information_geben
+UAV	das habe ich verstanden	Information_geben
+TL	Operator 1 und 2 für Teamleader, kommen	Kontakt_Anfrage
+UGV-1	hier Operator 1	Kontakt_Bestaetigung
+TL	wer von euch beiden hat 'n Foto gemacht auf der Treppe?	Information_nachfragen
+UGV-1	ja, das habe ich gemacht	Information_geben
+UAV	Benno für Lena	Kontakt_Anfrage
+TL	ich höre	Kontakt_Bestaetigung
+UAV	ich hab dir nochmal ein Bild ein herangezoomtes Bild geschickt, wo der Qualm besser zu sehen ist, aber keine Personen gefunden, von dieser Position aus	Information_geben
+TL	verstanden	Information_geben
+TL	Lena, dann flieg mal mit deinem Fluggerät da weiter ja, weiter nach rechts, würde ich jetzt erst mal sagen, was immer auch rechts sein mag so wie du jetzt guckst quasi in deiner Position in Richtung deiner Position	Einsatzbefehl
+TL	Lena für Benno?	Kontakt_Anfrage
+UAV	Lena hört	Kontakt_Bestaetigung
+TL	flieg mal mit der Drohne genau in die andere Richtung	Einsatzbefehl
+TL	ich seh dich auf dem Bildschirm	Information_geben
+UAV	wir müssen gerade den Akku tauschen	Information_geben
+UAV	ich schick dir jetzt noch mal ein Bild von weit oben rechts auf dem Bild, was nicht mehr zu sehen ist, sind diese drei klein' Hochöfen und links ist der ganz große gefüllte Hochofen	Information_geben
+UAV	genau in der Mitte davon, also bei den grünen, da kommt der Qualm her	Information_geben
+TL	verstanden	Information_geben
+UGV-1	der Teamleader von Operator 1, kommen	Kontakt_Anfrage
+TL	höre	Kontakt_Bestaetigung
+UGV-1	ja, ich hab den ersten Raum weitestgehend abgesucht, gerade so ein bisschen technische Schwierigkeiten	Information_geben
+UGV-1	geht's einmal die Treppe noch weiter hoch oder soll ich in der Ebene bleiben und nach weiteren Räumen suchen?	Information_nachfragen
+TL	ich melde mich sofort	Information_geben
+UGV-1	ja, verstanden	Information_geben
+UAV	Benno für Lena	Kontakt_Anfrage
+TL	ich höre	Kontakt_Bestaetigung
+UAV	kannst du jetzt nochmal genau beschreiben, wo ich hinfliegen sollte?	Information_nachfragen
+TL	ja, ich melde mich gleich	Information_geben
+TL	Operator 1 für Teamleader, kommen	Kontakt_Anfrage
+TL	Operator 1 für Teamleader, kommen	Kontakt_Anfrage
+TL	Operator 2 für Teamleader, kommen	Kontakt_Anfrage
+UGV-2	hört	Kontakt_Bestaetigung
+TL	was machen die technischen Probleme, wieder einsatzbereit?	Information_nachfragen
+UGV-2	negativ	Absage
+TL	verstanden	Information_geben
+UGV-2	wir stehen in der Nähe des grünen Fasses	Information_geben
+UGV-2	also ist das grüne Fass kann ich durch die Kamera sehen, aber ich kann ihn nicht verfahren	Information_geben
+UGV-2	das Radar scheint irgendwie nicht richtig zu funktionieren	Information_geben
+UGV-2	nicht ge- richtig	Sonstiges
+TL	kannst du dich denn noch bewegen?	Information_nachfragen
+UGV-2	ne, ich kann hier nichts machen	Absage
+UGV-2	es sind ja mit drei, vier Technikern die ganze Zeit am PC zugange	Information_geben
+TL	alles klar	Information_geben
+TL	Foto machen geht auch nicht?	Information_nachfragen
+UGV-2	ne	Absage
+UGV-2	ich mache hier gar nichts gerade am Rechner	Information_geben
+TL	alles klar	Information_geben
+UGV-2	Teamleader von Operator 2, kommen	Kontakt_Anfrage
+TL	ich höre	Kontakt_Bestaetigung
+UGV-2	ja, ich gucke mal, dass ich dir jetzt ein Foto schicke	Information_geben
+UGV-2	scheint weiter zu gehen bei uns	Information_geben
+TL	ja, verstanden	Information_geben
+TL	Lena für Benno	Kontakt_Anfrage
+UAV	Lena hört	Kontakt_Bestaetigung
+TL	wenn du jetzt startest, den Hochofen, der von euch weiter weg ist - von dort aus hätte ich gerne Bilder aus der Mitte zwischen den Hochöfen	Einsatzbefehl
+UAV	ja, das habe ich verstanden	Zusage
+TL	immer noch Menschen suchen, ne	Einsatzbefehl
+UAV	ja, das habe ich auch verstanden	Zusage
+UGV-2	ja, Benno für den Operator 2, kommen	Kontakt_Anfrage
+TL	ich höre	Kontakt_Bestaetigung
+UGV-2	ja, hier steht wieder alles	Information_geben
+TL	wo ist denn deine Position jetzt?	Information_nachfragen
+UGV-2	immer noch in der Nähe des grünen Fasses	Information_geben
+UGV-2	aber hier geht im Moment nichts	Information_geben
+TL	alles klar	Information_geben
+TL	Lena für Benno	Kontakt_Anfrage
+UAV	Lena hört	Kontakt_Bestaetigung
+TL	zwischen den Hochöfen, da steht irgendwo ein grünes Fass und da kommt die Rauchentwicklung her	Information_geben
+TL	ich hab im Moment keinen Roboter einsatzbereit	Information_geben
+TL	kannst du gucken, ob du dieses Fass findest und entsprechende Bilder machst?	Einsatzbefehl
+UAV	ja, das habe ich verstanden	Zusage
+UAV	das hab ich auch verstanden	Zusage
+UGV-2	so, der Benno für Operator 2, kommen	Kontakt_Anfrage
+TL	ich höre	Kontakt_Bestaetigung
+UGV-2	ja, es geht weiter	Information_geben
+UGV-2	ich habe dir ein Foto geschickt von dem grünen Fass und wo ich mich jetzt gerade befinde	Information_geben
+TL	ja, bleib mal da, wo du jetzt bist	Einsatzbefehl
+TL	dieses grüne Fass - da ist der Rauch, korrekt?	Information_nachfragen
+UGV-2	ja, ich weiß	Zusage
+UGV-2	ich seh den Rauch ab und zu	Information_geben
+UGV-2	soll ich in die Richtung fahren?	Information_nachfragen
+TL	fahr zu dem grünen Fass	Zusage
+TL	und erkunde um dieses grüne Fass herum, warum es da raucht	Einsatzbefehl
+UGV-2	ja, verstanden	Zusage
+TL	Operator 2 für Teamleader	Kontakt_Anfrage
+UGV-2	melde mich sofort	Sonstiges
+TL	so, der Benno an alle	Kontakt_Anfrage
+TL	Übungsende	Information_geben
+TL	die Roboter sollen alle zurückfahren und dann treffen wir uns hier	Einsatzbefehl
+TL	UGV 1 von Teamleader	Kontakt_Anfrage
+UGV-1	hier UGV 1, kommen	Kontakt_Bestaetigung
+TL	du bist soweit?	Information_nachfragen
+UGV-1	ja, natürlich	Zusage
+TL	UGV 2 von Teamleader	Kontakt_Anfrage
+UGV-2	hier UGV-	Sonstiges
+UGV-2	hier UGV 2	Kontakt_Bestaetigung
+TL	ihr seid auch soweit?	Information_nachfragen
+UGV-2	sind bereit, ja	Zusage
+TL	verstanden	Information_geben
+TL	UAV 1 von Teamleader	Kontakt_Anfrage
+UAV	hier UAV 1 kommen	Kontakt_Bestaetigung
+TL	ihr seid auch soweit?	Information_nachfragen
+UAV	bereit, wenn Sie es sind	Zusage
+TL	verstanden	Information_geben
+TL	der Einsatzauftrag kommt wunderbar	Information_geben
+MC	Teamleader von Mission Commander, kommen	Kontakt_Anfrage
+TL	Teamleader hört	Kontakt_Bestaetigung
+MC	wie besprochen Gebiet erkunden rund um die beiden Hochöfen	Einsatzbefehl
+MC	vermutlich Explosion, oder irgendwas mit Chemikalien	Information_geben
+MC	wir wissen nicht, ob es eine Leckage ist, oder was Anderes	Information_geben
+MC	Rauchentwicklung ist schon gemeldet worden	Information_geben
+MC	möglicherweise sind dann auch Personen vermisst	Information_geben
+MC	also Personensuche voran- bringen	Einsatzbefehl
+MC	und dann eventuell noch nach der Schadenursache gucken	Einsatzbefehl
+TL	das ist verstanden	Zusage
+TL	an UGV 1, UGV 2, UAV	Kontakt_Anfrage
+TL	kurze Lagedarstellung	Information_geben
+TL	es gab ein'n Zwischenfall zwischen zwei Hochöfen	Information_geben
+TL	dort werden eine oder mehrere Personen vermisst	Information_geben
+TL	eine Rauchentwicklung ist zu erkennen	Information_geben
+TL	und da ist das Einsatzgebiet	Information_geben
+TL	Auftrag für die UAV 1	Einsatzbefehl
+TL	hören Sie mit?	Kontakt_Anfrage
+UAV	UAV hört	Kontakt_Bestaetigung
+TL	genau	Information_geben
+TL	Auftrag für die UAV 1	Einsatzbefehl
+TL	ich brauch' einmal ein Lagebild von oben, wo das komplette Objekt abgebildet wird und dann speziell ein Foto zwischen den beiden Türen	Einsatzbefehl
+TL	verstanden?	Information_nachfragen
+UAV	ein Lagebild von oben komplette Lage und ein Lagebild zwischen den beiden Türen, verstanden	Zusage
+TL	das ist korrekt	Information_geben
+TL	bitte, auch per Infrarot, bitte	Einsatzbefehl
+TL	auf Menschen und sonstige Ereignisse scannen	Einsatzbefehl
+UAV	ja, beide Bilder in Infrarot ebenfalls	Zusage
+TL	korrekt	Information_geben
+TL	UGV 1 von Teamleader?	Kontakt_Anfrage
+UGV-1	UGV 1, kommen	Kontakt_Bestaetigung
+TL	ja, Ihr Auftrag ist in das Objekt reinzufahren und den Schadensort zu scannen, zu bebildern	Einsatzbefehl
+UGV-1	ja, verstanden	Zusage
+UGV-1	ich fahr rein	Information_geben
+TL	UGV 2 von Teamleader?	Kontakt_Anfrage
+UGV-2	UGV 2, kommen	Kontakt_Bestaetigung
+TL	ebenfalls Ihr Auftrag vom Westen her Richtung Osten die Einsatzstelle anfahren mir Ihrem UGV und Kontrolle ob Menschen zu erkennen sind, beziehungsweise, ob irgend ein Schadensereignis zu erkennen ist	Einsatzbefehl
+UGV-2	verstanden	Zusage
+TL	Mission Commander von Teamleader	Kontakt_Anfrage
+MC	kommen Sie	Kontakt_Bestaetigung
+TL	ja	Sonstiges
+TL	erste Maßnahmen eingeleitet, wir erstellen ein Lagebild mit der Drohne von oben und per Infrarot	Information_geben
+TL	des Weiteren die zwei UGVs eingeteilt die fahren vor, zum Schadensereignis, zwecks Menschensuche und weitere Lagedarstellung	Information_geben
+MC	verstanden	Information_geben
+MC	Teamleader von Mission Commander, kommen	Kontakt_Anfrage
+TL	Teamleader hört	Kontakt_Bestaetigung
+MC	welcher Roboter ist jetzt für die Verletztensuche eingeteilt?	Information_nachfragen
+TL	UGV 1 und UGV 2	Information_geben
+TL	die suchen Verletzte ein- feststellen	Sonstiges
+TL	die suchen Verletzte, feststellen, was da genau los ist	Information_geben
+MC	ja, verstanden	Information_geben
+MC	Teamleader von Mission Commander, kommen	Kontakt_Anfrage
+TL	Teamleader hört	Kontakt_Bestaetigung
+MC	Bild von der UAV eingetroffen?	Information_nachfragen
+TL	ja, das erste Bild	Zusage
+UGV-1	Teamleader von UGV 1	Kontakt_Anfrage
+TL	Teamleader hört	Kontakt_Bestaetigung
+UGV-1	Rauchentwicklung erste Treppe nach oben,	Information_geben
+UGV-1	ich schick dir mal ein Screenshot	Information_geben
+TL	korrekt	Zusage
+TL	und wenn weitere Erkenntnis, das auch melden	Einsatzbefehl
+MC	Teamleader von Mission Commander, kommen	Kontakt_Anfrage
+TL	Teamleader hört	Kontakt_Bestaetigung
+MC	aus dem ersten Foto von der UAV mit der Übersicht ist da so ein heller Fleck zu sehen	Information_geben
+MC	vielleicht kann man nochmal dran zoomen	Einsatzbefehl
+MC	ich weiß nicht, was das ist - ob das jetzt eine Person ist, oder - das ist	Sonstiges
+MC	ich weiß nicht, was das ist - ob das jetzt eine Person ist, das ist unten am unteren Rand, da ist ein [<unintelligible>]	Information_geben
+MC	kommen	Kontakt_Anfrage
+UGV-1	Teamleader von UGV 1, kommen	Kontakt_Anfrage
+TL	Teamleader hört	Kontakt_Bestaetigung
+UGV-1	ja, ich werde jetzt die Treppe mal hochfahren und weiter erkunden oben	Information_geben
+TL	ja	Zusage
+TL	ja, verstanden	Information_geben
+TL	UGV 1, ist das die erste Etage oder so ne - nur fünf Stufen?	Information_nachfragen
+UGV-1	ja, zwölf Metallstufen	Information_geben
+TL	verstanden	Information_geben
+TL	mach mal ein Foto davon	Einsatzbefehl
+UGV-2	Teamleader für UGV 2, kommen	Kontakt_Anfrage
+TL	Teamleader hört	Kontakt_Bestaetigung
+UGV-2	ich bin jetzt auch in der Nähe vom Hochofen angekommen, ich sehe Rauchentwicklung und auch einen umgestürtzten blauen Kanister	Information_geben
+UGV-2	ich schicke Ihnen gleich mal ein Screenshot drüber	Information_geben
+TL	ja, genau	Zusage
+TL	bitte darauf achten, eine Bezeichnung auf dem Kanister zu erkennen	Einsatzbefehl
+UGV-2	verstanden	Zusage
+MC	Teamleader von Mission Commander, kommen	Kontakt_Anfrage
+TL	Teamleader hört	Kontakt_Bestaetigung
+MC	liegen irgend welche Erkenntnisse nochmal vor, inwiefern die Strukturen noch stabil genug sind, um Eingriffstrupp reinzuschicken?	Information_nachfragen
+TL	UGV 1, UGV 2	Kontakt_Anfrage
+TL	könnt ihr abschätzen, ob das Gebäude noch Tragfähigkeit hat?	Information_nachfragen
+UGV-2	Teamleader für UGV2, kommen	Kontakt_Anfrage
+UGV-2	Teamleader für UGV2, kommen	Kontakt_Anfrage
+TL	Teamleader hört	Kontakt_Bestaetigung
+UGV-2	ich habe jetzt d- den Kanister gefunden, es handelt sich um Otalin Pera-cet, zirka 20 bis 30 liter Fassungsvermögen, es scheint auch eine Leckage da zu sein	Information_geben
+UGV-2	d- den Kanister	Sonstiges
+UGV-2	darüber hinaus habe ich auch - sehe ich auch Teile v-vom Gebäude hier liegen, also es - ist - die strukturelle Integrität könnte gefährdet sein	Information_geben
+UGV-2	darüber hinaus habe ich auch - sehe ich auch	Sonstiges
+UGV-2	v-vom Gebäude	Sonstiges
+UGV-2	also es - ist - die strukturelle Integrität könnte gefährdet sein	Sonstiges
+TL	ja, verstanden	Information_geben
+TL	Mission Commander von Teamleader	Kontakt_Anfrage
+MC	kommen Sie	Kontakt_Bestaetigung
+TL	ja, diese Substanz wurde gefunden, ein Foto folgt	Information_geben
+MC	ja, verstanden	Information_geben
+UGV-2	Teamleader für UGV2	Kontakt_Anfrage
+UGV-2	ich habe jetzt ein Foto gemacht und geschickt, vom Conta- von dem Kanister	Information_geben
+UGV-2	vom Conta- von dem Kanister	Sonstiges
+TL	verstanden	Information_geben
+MC	Teamleader v-von Mission Commander, kommen	Kontakt_Anfrage
+MC	v-von	Sonstiges
+TL	Teamleader hört	Kontakt_Bestaetigung
+MC	sind schon Verletzte gefunden worden?	Information_nachfragen
+TL	bisher noch nicht, wir haben eine Erkenntnis auf auf einem Foto, dem gehen wir jetzt nach	Information_geben
+UGV-2	Teamleader für UGV2, kommen	Kontakt_Anfrage
+UGV-2	Teamleader für UGV2, kommen	Kontakt_Anfrage
+UGV-2	Teamleader für UGV2, kommen	Kontakt_Anfrage
+UAV	Teamleader von UAV-Operator, kommen	Kontakt_Anfrage
+UAV	Teamleader	Kontakt_Bestaetigung
+MC	Teamleader von Mission Commander, kommen	Kontakt_Anfrage
+TL	Teamleader hört	Kontakt_Bestaetigung
+MC	Foto von dem blauen Kanister ist eingetroffen	Information_geben
+MC	auf Nachfrage handelt es sich um Kraftstoff	Information_geben
+MC	Frage ist der Kanister defekt, hat eine Leckage oder ist er noch dicht?	Information_nachfragen
+TL	ich klär das	Information_geben
+TL	UGV2 für Teamleader?	Kontakt_Anfrage
+UGV-2	UGV2, kommen	Kontakt_Bestaetigung
+TL	ja, der Kanister mit Otalin, ist er defekt?	Information_nachfragen
+TL	ist nur eine kleine Lache, oder ist er komplett ausgelaufen?	Information_nachfragen
+TL	wie viel Liter sind das?	Information_nachfragen
+UGV-2	so, ich kann nicht genau einschätzen, wie viel ausgelaufen ist	Information_geben
+UGV-2	aber eine Leckage hat stattgefunden	Information_geben
+UGV-2	der K-Kanister hat zirka 30 liter Fassvermögen	Information_geben
+UGV-2	K-Kanister	Sonstiges
+UGV-2	ich kann aber eine Probe nehmen, ich habe einen Arm dabei	Information_geben
+TL	ja	Zusage
+TL	dann bitte eine Probe nehmen	Einsatzbefehl
+TL	gibt's irgendwelche Erkenntnisse, wo die Rauchentwicklung herkommt?	Information_nachfragen
+UGV-1	der GUV1 hat jetzt die Treppe erklommen, ich werd' nach der Rauchquelle suchen	Information_geben
+TL	das ist verstanden	Information_geben
+UGV-1	aber mein Laser ist ausgefallen, ich kann nur noch optisch fahren, ist schon sehr verraucht	Information_geben
+TL	ja, verstanden	Information_geben
+TL	du hast doch auch eine Infrarot-Kamera drauf	Information_nachfragen
+TL	kannst du damit was erkennen?	Information_nachfragen
+UGV-1	die funktioniert doch nicht	Absage
+TL	ja, verstehe	Information_geben
+MC	Teamleader für Mission Commander	Kontakt_Anfrage
+TL	Teamleader hört	Kontakt_Bestaetigung
+MC	wir müssten eine Stelle mal genauer untersuchen	Einsatzbefehl
+UGV-1	Teamleader von UGV1, kommen	Kontakt_Anfrage
+UGV-2	Teamleader für UGV2, kommen	Kontakt_Anfrage
+TL	kurz warten	Sonstiges
+TL	Teamleader hört	Kontakt_Bestaetigung
+UGV-2	wir haben jetzt eine Probe genommen und auch dabei	Information_geben
+UGV-2	sollen wir jetzt die Suche fortsetzen nach Verletzten, oder zurückkehren, um die Probe zu analysieren?	Information_nachfragen
+TL	ja, wir konnten bereits feststellen, das Otalin was es genau ist fortsetzen der Suche	Information_geben
+UGV-1	Thorsten, kannst du mich noch hören?	Information_nachfragen
+UGV-1	Teamleader von UGV1, kommen	Kontakt_Anfrage
+TL	Mission Commander von Teamleader	Kontakt_Anfrage
+MC	Mission Commander hört	Kontakt_Bestaetigung
+TL	ja, Rückmeldung	Information_geben
+TL	Trupp eine Person gefunden, wieder aus dem Gefahrenbereich	Information_geben
+TL	geht jetzt und an den Rettungsdienst übergeben	Information_geben
+MC	ja, verstanden	Information_geben
+MC	wir bräuchten mal eine genauere Untersuchung, Bild Nummer 3	Einsatzbefehl
+UGV-1	Teamleader von UGV1, kommen	Kontakt_Anfrage
+MC	Teamleader von Mission Commander, kommen	Kontakt_Anfrage
+TL	ja, war- kurz warten	Sonstiges
+TL	war- kurz warten	Sonstiges
+TL	UGV1 von Teamleader	Kontakt_Anfrage
+UGV-1	ja	Kontakt_Bestaetigung
+UGV-1	die Verrauchung kommt aus einem grünen Fass, ich hab mal ein Screenshot geschickt	Information_geben
+UGV-1	ich versuch' die Beschriftung noch besser zu fotografieren	Information_geben
+UGV-1	es ist aber sehr verraucht	Information_geben
+UGV-1	und mein Laser ist ausgefallen	Information_geben
+TL	das ist verstanden	Information_geben
+UGV-2	Teamleader für UGV2, kommen	Kontakt_Anfrage
+TL	Teamleader hört	Kontakt_Bestaetigung
+UGV-2	wir sind jetzt auch an dem grünen Kanister angekommen	Information_geben
+UGV-2	wir haben einen Arm dabei, sehen auch den zweiten Roboter	Information_geben
+UGV-2	wir können vielleicht etwas bessere Bilder machen	Information_geben
+TL	ja, genau	Zusage
+TL	und da wieder die Kennzeichnung, die brauchen wir	Einsatzbefehl
+TL	und eine Einschätzung, ob Undichtigkeit, und wenn ja, wie viel Flüssigkeit ausgetreten ist	Einsatzbefehl
+MC	so, jetzt mal stopp	Einsatzbefehl
+MC	Teamleader für Mission Commander	Kontakt_Anfrage
+MC	eine verletzte Person hier in diesen Strukturen	Information_geben
+MC	Teamleader von Mission Commander	Kontakt_Anfrage
+UGV-2	Teamleader für UGV2, kommen	Kontakt_Anfrage
+UGV-1	Teamleader-Funk ist ausgefallen	Information_geben
+UGV-2	Teamleader für UGV2, kommen	Kontakt_Anfrage
+MC	Teamleader für Mission Commander, kommen	Kontakt_Anfrage
+UGV-1	Teamleader-Funk ist ausgefallen	Information_geben
+MC	okay	Information_geben
+TL	so, der Team- der Teamleader hört wieder	Information_geben
+TL	der Team- der Teamleader	Sonstiges
+TL	Funk funktioniert wieder	Information_geben
+UGV-2	Teamleader für UGV2, kommen	Kontakt_Anfrage
+TL	Teamleader hört	Kontakt_Bestaetigung
+UGV-2	wir haben den grünen Container identifiziert, haben auch ein Foto gemacht, und es - es müsste in der Datenbank liegen	Information_geben
+UGV-2	es scheint - handelt sich um eine gift- giftige entzündliche - hochentzündliche Flüssigkeit	Information_geben
+UGV-2	es scheint - handelt sich	Sonstiges
+UGV-2	eine gift- giftige	Sonstiges
+UGV-2	entzündliche - hochentzündliche	Information_geben
+UGV-1	UGV2 von 1	Kontakt_Anfrage
+UGV-2	UGV1, kommen	Kontakt_Bestaetigung
+UGV-1	davor ist noch ein gelber Kanister, brennbares Material, den hab ich auch mit fotografiert	Information_geben
+UGV-2	super, den habe ich noch nicht gesehen	Information_geben
+UGV-2	danke schön	Sonstiges
+MC	Teamleader von Mission Commander, kommen	Kontakt_Anfrage
+MC	Teamleader von Mission Commander, kommen	Kontakt_Anfrage
+TL	Teamleader hört	Kontakt_Bestaetigung
+MC	wie ist der Stand der Rettung der Verletzten?	Information_nachfragen
+TL	ein Trupp arbeitet sich vor der Flug-Roboter fliegt vor die Position des Verletzten z- zwecks besseres Auffinden	Information_geben
+TL	z- zwecks	Sonstiges
+MC	ja, verstanden	Information_geben
+UGV-1	Teamleader von UGV1, kommen	Kontakt_Anfrage
+TL	Teamleader hört	Kontakt_Bestaetigung
+UGV-1	ja, ich bin an der Grenze zur Datenübertragung, habe ich so den Eindruck	Information_geben
+UGV-1	da geht alles etwas langsamer, aber ich versuch' mal hier die Gegend noch weiter abzusuchen	Information_geben
+TL	ja	Zusage
+UGV-2	Teamleader für UGV2, kommen	Kontakt_Anfrage
+UGV-2	Teamleader für UGV2, kommen	Kontakt_Anfrage
+TL	Teamleader hört	Kontakt_Bestaetigung
+UGV-2	wir haben noch eine weitere Flasche gefunden, mit 'ner Chemikalie	Information_geben
+UGV-2	wir haben ein Foto gemacht	Information_geben
+UGV-2	das schicke ich jetzt rüber	Information_geben
+TL	ja, verstanden	Information_geben
+MC	Teamleader für Mission Commander, kommen	Kontakt_Anfrage
+TL	Teamleader hört	Kontakt_Bestaetigung
+MC	aus dem Foto sehe ich jetzt drei Behältnisse	Information_geben
+MC	haben wir das grüne Fass dann einen roten Kanister und das untere ist ein blauer umgestürtzter Eimer, oder was?	Information_nachfragen
+MC	gibt's da nähere Erkenntnisse drüber?	Information_nachfragen
+TL	ja, die Erkenntnisse, was auf dem Foto zu erkennen ist	Information_geben
+TL	brennbarer, mit Wasser gefährlicher, gährender Stoff alles Weitere müsst ihr von der Einsatzseite eruieren	Information_geben
+MC	ja, die Bilder sind nicht so ganz scharf	Information_geben
+MC	kann er noch vielleicht mal eine bessere Auflösung schicken?	Einsatzbefehl
+TL	ich kümmere mich drum	Zusage
+TL	UGV 2 von Teamleader	Kontakt_Anfrage
+UGV-2	UGV 2, kommen	Kontakt_Bestaetigung
+TL	ja, UGV 2, wir brauchen nochmal schärfere Bilder von dem Fass und der Kennzeichnung	Einsatzbefehl
+UGV-2	ich habe Sie nicht gut verstanden, können Sie wiederholen?	Information_nachfragen
+TL	ja, von dem Fass brauchen wir nochmal bessere Bilder, und auch von der Kennzeichnung	Einsatzbefehl
+UGV-2	ja, ich versuche nochmal zu dem Fass zu fahren	Zusage
+UGV-2	es ist sehr verraucht, mittlerweile	Information_geben
+UGV-2	aber ich versuche, bessere Bilder aufzunehmen	Information_geben
+UGV-1	der UGV 1 ist auch in der Nähe, ich kann auch nochmal gucken	Information_geben
+UGV-2	Teamleader vo- für UGV 2, kommen	Kontakt_Anfrage
+UGV-2	vo- für	Sonstiges
+MC	Teamleader für Mission Commander	Kontakt_Anfrage
+TL	Teamleader hört	Kontakt_Bestaetigung
+MC	nach den Fotos müsste die verletzte Person am linken Hochofen liegen und die UGV 2 müsste da dran vorbei gefahren sein	Information_geben
+MC	und zwar, zwischen der Halle hier, wo wir sind, und dem Hochofen	Information_geben
+MC	da müsste die Person liegen	Information_geben
+UAV	der Einsatleiter vom Operator UAV, kommen	Kontakt_Anfrage
+TL	ich hör' dich	Kontakt_Bestaetigung
+UAV	also, derzeit sind wir nicht startbereit mit der UAV	Information_geben
+UAV	weil es noch zu sehr regnet	Information_geben
+TL	hab verstanden	Information_geben
+TL	UGV 1, UGV 2 seid ihr startklar?	Information_nachfragen
+UGV-1	ja, ich rolle bereits	Zusage
+UGV-2	ja, ich rolle auch schon	Zusage
+TL	verstanden	Information_geben
+TL	UGV 1, hast du schon ein Bild gemacht?	Information_nachfragen
+UGV-1	ist negativ, noch nicht	Absage
+TL	dann bitte mal eins gerade vorweg	Einsatzbefehl
+UGV-2	Teamleader von UGV 2	Kontakt_Anfrage
+TL	hör' dich	Kontakt_Bestaetigung
+UGV-2	ja, ich hab ein grünes Fass ausgemacht, und Rauch	Information_geben
+UGV-2	hab dir ein Bild gemacht und geteilt	Information_geben
+TL	verstanden	Information_geben
+UGV-1	Teamleader von UGV 1	Kontakt_Anfrage
+UGV-1	starke Rauchentwicklung vor mir	Information_geben
+UGV-1	ich mach ein Foto und schick's dir	Information_geben
+TL	Teamleader, verstanden	Information_geben
+UGV-2	Teamleader von UGV 2	Kontakt_Anfrage
+UGV-2	im ersten Obergeschoss ein grünes Fass und starke Rauchentwicklung	Information_geben
+TL	ja, verstanden	Information_geben
+TL	Bild hast du verschickt?	Information_nachfragen
+UGV-2	korrekt	Zusage
+UGV-1	Teamleader von UGV 1	Kontakt_Anfrage
+UGV-1	ich verlasse das Erdgeschoss und gehe ins erste Obergeschoss	Information_geben
+TL	Teamleader, verstanden	Information_geben
+TL	UGV 2 von Teamleader	Kontakt_Anfrage
+UGV-2	hört	Kontakt_Bestaetigung
+TL	hast du eine Möglichkeit, dass Fass näher zu identifizieren, was da drin ist?	Information_nachfragen
+UGV-2	ja, warten	Zusage
+UGV-1	Teamleader von UGV 1	Kontakt_Anfrage
+UGV-1	ich habe die Nebelmaschine gefunden	Information_geben
+TL	ja, verstanden	Information_geben
+TL	mach mal ein Foto	Einsatzbefehl
+TL	UGV 2 von Teamleader, kommen	Kontakt_Anfrage
+UGV-2	hört	Kontakt_Bestaetigung
+TL	Frage gerade: aktueller Standort?	Information_nachfragen
+UGV-2	im ersten Obergeschoss vor einem Hochofen rechtsseitig ein grünes Fass und Rauchentwicklung	Information_geben
+UGV-1	Teamleader, UGV 1	Kontakt_Anfrage
+TL	Teamleader hört	Kontakt_Bestaetigung
+UGV-1	ja, ich hab 'n blaues Fass gefunden mit Aufschrift	Information_geben
+UGV-1	hab dir ein Foto geschickt und werde mich dem jetzt nähern	Information_geben
+TL	UGV 1 von Teamleader	Kontakt_Anfrage
+TL	UGV 1 von Teamleader, kommen	Kontakt_Anfrage
+UGV-1	ich höre	Kontakt_Bestaetigung
+TL	kommst du näher an das blaue Fass, dass wir eine Erkennung haben?	Information_nachfragen
+UGV-1	ja, ich fahr' gerade näher	Zusage
+UGV-1	Teamleader von UGV 1	Kontakt_Anfrage
+TL	UGV 1?	Kontakt_Bestaetigung
+UGV-1	ja, es handelt sich um einen blauen Kanister, der aufrecht steht, verschlossen ist mit dem Inhalt Otalin	Information_geben
+UGV-1	ich hab ein Foto gemacht und schick's dir	Information_geben
+TL	verstanden	Information_geben
+UGV-1	von außen keine Gefahrensymbole von der Vorderseite	Information_geben
+UGV-1	ich werde jetzt noch die rechte Seite erkunden	Information_geben
+TL	zu allen Roboter mal kurz Stop	Einsatzbefehl
+TL	UAV für Einsatzleiter	Kontakt_Anfrage
+UGV-1	können wir weitermachen?	Information_nachfragen
+TL	warten	Absage
+TL	UAV für Teamleader	Kontakt_Anfrage
+UAV	UAV hört	Kontakt_Bestaetigung
+TL	Frage: Einsatzbereitschaft?	Information_nachfragen
+UAV	negativ	Absage
+TL	melden wenn Einsatzbereitschaft gegeben	Einsatzbefehl
+UAV	verstanden	Information_geben
+UGV-1	Teamleader von UGV 1	Kontakt_Anfrage
+TL	Teamleader hört	Kontakt_Bestaetigung
+UGV-1	ja, Frage: kommen meine Fotos an?	Information_nachfragen
+TL	warten	Sonstiges
+UGV-1	müsste ein blauer Kanister sein	Information_geben
+UGV-1	ich habe weiterhin eine grüne Tonne mit einer drauf befindlichen Flasche gefunden	Information_geben
+UGV-2	auf dem Weg zu der Tonne mit der Flasche obendrauf, da befinde ich mich gerade	Information_geben
+UGV-1	ja okay, dann müsste ich dich ja sehen	Information_geben
+UGV-1	der steht ja vor die Nebelmaschine?	Information_nachfragen
+UGV-2	ne, ich bin vor diesem Hochofen der mehrere Bullaugen hat	Information_geben
+UGV-2	sag ich mal, ne	Absage
+UGV-2	und da bin ich auf einer Seite vom Geländer	Information_geben
+UGV-2	ich umfahre jetzt diese Bullaugen und müsste dann direkt vor dem Fass stehen	Information_geben
+UGV-1	ja, das ist negativ	Absage
+UGV-1	ich stehe vor dem Fass	Information_geben
+UGV-1	so kannst du auf deiner Seite bleiben	Information_geben
+UGV-2	na ja gut, dann mach du ein Foto von dem Fass	Zusage
+UGV-2	und ich drehe um und erkunde die andere Seite	Information_geben
+TL	UGV 1 von Teamleader, kommen	Kontakt_Anfrage
+UGV-1	kommen Sie	Kontakt_Bestaetigung
+TL	Frage: hast du ein Foto von dem grünen Fass gemacht?	Information_nachfragen
+UGV-1	ja, ist korrekt	Zusage
+UGV-1	grüne Fass mit Flasche drauf	Information_geben
+UGV-1	werde aber jetzt auch mal die rückwärtige Seite des Fasses erkunden	Information_geben
+TL	UGV 1 damit warten	Einsatzbefehl
+UGV-1	also, ich stehe jetzt genau vor dem Fass	Information_geben
+UGV-1	ich werde nochmal ein Foto machen und dir schicken	Information_geben
+UGV-2	können wir weiterfahren oder warten wir noch?	Information_nachfragen
+TL	ja, können weiter fahren	Information_geben
+TL	UGV 1 aber warten	Einsatzbefehl
+UGV-1	ja, das verstanden	Zusage
+UGV-1	weitere Foto von grünen Fass mit grüner Flasche drauf wurde dir entsandt	Information_geben
+UGV-2	ja, UGV 2, ich dreh dann um und erkunde die andere Gebäudeseite	Information_geben
+TL	Teamleiter, verstanden	Information_geben
+TL	UGV 1 von Teamleader	Kontakt_Anfrage
+UGV-1	kommen	Kontakt_Bestaetigung
+TL	ja, jetzt haben wir die Erkundung der rückwärtigen Seite in nördlicher Bereich	Information_geben
+UGV-1	welche rückwärtige Seite, vom Fass?	Information_nachfragen
+UGV-2	Teamleader von UGV 2	Kontakt_Anfrage
+TL	UGV 2, hört	Kontakt_Bestaetigung
+UGV-2	ja, von meiner jetztigen Position aus ist quasi aus der Halle raus kein Rauch und keine Gefahren zu erkennen	Information_geben
+UGV-2	Frage, anderer Auftrag?	Information_nachfragen
+TL	mach mal ein Foto zur Orientierung für mich	Information_geben
+UGV-2	hab ich schon	Information_geben
+UGV-2	Teamleader von UGV 2	Kontakt_Anfrage
+TL	UGV, warten	Sonstiges
+UGV-2	Teamleader von UGV 2	Kontakt_Anfrage
+TL	warten	Sonstiges
+TL	UGV 2 von Teamleader, kommen	Kontakt_Anfrage
+UGV-2	UGV 2 hört	Kontakt_Bestaetigung
+UGV-1	Teamleader von UGV 1	Kontakt_Anfrage
+TL	Teamleader hört	Kontakt_Bestaetigung
+UGV-1	ja, ich hab dir jetzt erneut das Foto geschickt	Information_geben
+UGV-1	ich konnte beide Rauchquellen identifizieren, beides Nebelmaschinen	Information_geben
+UGV-1	hab dir jetzt ein Übersichtsfoto geschickt von einmal den blauen Kanister und dem grünen Fass mit der grünen Flasche drauf	Information_geben
+TL	das ist verstanden	Information_geben
+UGV-1	jetzt die Frage, ob ich mich weiter fortbewegen soll	Information_nachfragen
+UGV-1	ich kann das Fass noch einmal umkreisen und gucken ob es eine Beschriftung drauf ist	Information_geben
+TL	negativ	Absage
+TL	UGV 1, UGV 2	Kontakt_Anfrage
+TL	gab es Möglichkeiten eine Etage weiter nach oben zu kommen?	Information_nachfragen
+UGV-2	ja, UGV 2	Zusage
+UGV-2	ich hab hier einen Treppenraum	Information_geben
+TL	nach oben?	Information_nachfragen
+UGV-2	das ist korrekt	Zusage
+TL	Möglichkeiten, mit dem Bodenroboter da hochzufahren?	Information_nachfragen
+UGV-2	ja, ich kann das mal probieren	Zusage
+TL	dann Erkundung zweiter Obergeschoss	Einsatzbefehl
+UGV-1	Teamleader von UGV 1	Kontakt_Anfrage
+UGV-1	ich muss mich erst mal orientiere und gucken, ob ich irgendwo hochkomme	Information_geben
+UGV-1	zur Zeit hier bei den Fässern kann ich nicht hoch	Information_geben
+TL	verstanden	Information_geben
+UGV-1	UGV 1 Teamleader von UGV 1	Kontakt_Anfrage
+TL	UGV 1, höre	Kontakt_Bestaetigung
+TL	kommen	Kontakt_Bestaetigung
+UGV-1	ja, ich hab jetzt das Fass einmal umkreist kann auf dem Fass zwei Gefahrensymbole identifizieren, einmal rot mit Flamme, brennbar und einmal umweltgefährdend	Information_geben
+UGV-1	werde davon ein Foto machen und dir zusanden	Information_geben
+UGV-1	und eine UN-Nummer kann ich erkennen	Information_geben
+TL	verstanden	Information_geben
+UGV-1	es handelt sich um die UN-Nummer 12 03 moment	Information_geben
+UGV-1	Teamleader von UGV 1	Kontakt_Anfrage
+UGV-1	Fotos sind raus	Information_geben
+UGV-1	ich kann nur bestätigen, UN-Nummer 12 03, Gefahrenzettel leicht entflammbar und umweltgefährdend	Information_geben
+TL	verstanden	Information_geben
+UGV-1	noch als Zusatz, dieses Fass scheint nicht auszulaufen	Information_geben
+UGV-1	steht aufrecht und ist keinerlei Flüssigkeitsaustritt zu erkennen	Information_geben
+TL	verstanden	Information_geben
+UGV-1	ich werde jetzt versuchen, ins Obergeschoss zu kommen	Information_geben
+TL	wiederholen	Einsatzbefehl
+UGV-1	ich werde jetzt auch einen Weg suchen, ins Obergeschoss zu kommen	Information_geben
+TL	ja, ist verstanden	Information_geben
+TL	UGV 2 von Teamleader	Kontakt_Anfrage
+UGV-2	UGV 2 hört	Kontakt_Bestaetigung
+TL	viel Erfolg mit dem Treppenbesteigen?	Information_nachfragen
+UGV-2	ja, negativ	Absage
+UGV-2	ich hab hier gerade Probleme mit mir selbst	Information_geben
+UGV-1	ja, hier ist der UGV 1 von Teamleader	Kontakt_Anfrage
+TL	hör dich	Kontakt_Bestaetigung
+UGV-1	ja, ich hab ein weiteres grünes Fass gefunden beim Erkunden der Treppe gefunden in der Nähe von dem anderen aufrecht stehenden Fass festzustellen	Information_geben
+UGV-1	werde dies jetzt fotografieren und einmal um-kreisen, um eine Leckage	Information_geben
+TL	ja, ist verstanden	Information_geben
+TL	kannst du einmal ein Foto von dem Fass machen in Richtung der Treppe, dass man einen Orientierungspunkt hat?	Einsatzbefehl
+UGV-1	ja, das kann ich versuchen	Zusage
+UGV-1	ich kann höchstens so fotografieren, dass ich halt den Hochofen drauf hab'	Information_geben
+TL	ja, verstanden	Information_geben
+UGV-1	ja, wir können die Orientierung nehmen von dem ersten Fass von dem ersten Fass geht's ja die Treppe hoch, und da stand direkt das erste Fass und davon gesehen dann rechts	Information_geben
+TL	ja, machen wir so	Zusage
+UGV-1	also, ich werde das nachher nachvollziehen können	Information_geben
+UGV-1	Teamleader von UGV 1	Kontakt_Anfrage
+TL	Teamleader hört	Kontakt_Bestaetigung
+TL	ja, das zweite Fass ist liegt auf dem Boden ist aber auch augenscheinlich verschlossen, läuft nichts aus, keine Flüssigkeit läuft aus	Information_geben
+TL	das ist verstanden	Information_geben
+UGV-1	hab auch davon ein Foto gemacht und dir zugesandt	Information_geben
+UGV-1	da siehst du im hinteren Bereich des des Fasses auch die Öffnung die Bullaugen des Hochofens, also können wir uns daran orientieren	Information_geben
+TL	wiederholen	Einsatzbefehl
+UGV-1	wenn du das Foto von dem Fass siehst, siehst du im hinteren Bereich, hinter dem Fass die Bullaugen des Hochofens	Information_geben
+TL	verstanden	Information_geben
+UGV-1	ja, Teamleader von UGV 1	Kontakt_Anfrage
+TL	UGV 1, kommen	Kontakt_Bestaetigung
+UGV-1	ja, Frage: soll ich weiter erkunden? das Fass liegen lassen, weiterfahren?	Information_nachfragen
+TL	UGV 1, UGV 2, kommen	Kontakt_Anfrage
+UGV-1	UGV 1 hört	Kontakt_Bestaetigung
+UGV-2	UGV 2 hört	Kontakt_Bestaetigung
+TL	Maßnahme momentan: warten, wir machen hier gerade Übergabe	Information_geben
+UGV-1	okay	Information_geben
+UGV-2	hier UGV 2, verstanden	Information_geben
+TL	UGV 1, versuch noch in kochsweite ein bisschen nähere Ergebnisse zu kriegen	Einsatzbefehl
+UGV-2	ja, UGV 1 von UGV 2	Kontakt_Anfrage
+UGV-1	kommen	Kontakt_Bestaetigung
+UGV-2	ja, ich hab hier technische Probleme	Information_geben
+UGV-2	ich kann meine Flipper nicht bewegen und der Laser hat hinter sich	Information_geben
+UGV-1	ich hab jetzt nochmal ein Foto gesendet wo man das auch seiteliegende Fass und den blauen Kanister so im rückwärtigen Bereich erkennen kann	Information_geben
+UGV-1	da musst du genau hingucken	Einsatzbefehl
+TL	kannst du mir weitere Details zu dem liegenden Fass geben? eine Nummer, zum Beispiel?	Information_nachfragen
+UGV-1	ja, das ist negativ	Information_geben
+UGV-1	das Fass wurde einmal umkreist es liegt wahrscheinlich genau darauf	Information_geben
+UGV-1	ich kann mal versuchen mal es ein bisschen zu drehen	Information_geben
+TL	ja, verstanden	Zusage
+TL	aber sehr vorsichtig beim Vorgehen	Zusage
+UGV-1	ja, ist verstanden	Information_geben
+TL	sieht man irgendwo eine Leckage in der Nähe des Fasses?	Information_nachfragen
+UGV-1	ja, das ist negativ	Absage
+UGV-1	keine Leckage, aus dem Fass läuft nichts aus	Information_geben
+UGV-1	beide Verschluss-Stopfen sind fest verschlossen	Information_geben
+TL	beide Fässer sind noch nicht beschädigt	Information_geben
+UGV-1	da, das ist korrekt	Information_geben
+UGV-1	nur auf dem einen stehenden grünen Fass steht noch eine grüne Flasche	Information_geben
+TL	was kann in der grünen Flasche drin sein?	Information_nachfragen
+UGV-1	es sieht aus wie Gerolsteiner	Information_geben
+TL	weitere Erkenntnisse um das Fass herum an Leckagen?	Information_nachfragen
+TL	da es ja eine Explosion gewesen ist	Information_geben
+TL	kann man da irgendwo was sehen? sehen wo es ein drittes Fass im Umlauf liegen könnte	Information_nachfragen
+UGV-1	also, im Moment kann ich dazu nichts sagen	Information_geben
+UGV-1	um diesen beiden Fässern und dem Kanister ist kein Anschein von irgend einer Leckageaber erneut nochmal versuchen muss	Information_geben
+UGV-1	ich versuche jetzt noch von dem liegenden Fass die UN-Nummer rauszu'kommen, was ich bereits schon gedreht hab was ich	Information_geben
+TL	ja, verstanden	Information_geben
+UGV-2	ja, Teamleader von UGV 2	Kontakt_Anfrage
+TL	hört	Kontakt_Bestaetigung
+UGV-2	ja, ich versuche eigentlich, ins zweite Obergeschoss zu kommen	Information_geben
+UGV-2	aber ich hab hier erhebliche Probleme mit der Technik mein Roboter ist Made in Taiwan	Information_geben
+TL	kann man es denn manuell nicht beheben?	Information_nachfragen
+UGV-2	ich glaube nicht	Absage
+TL	UGV 1	Kontakt_Anfrage
+UGV-1	ja, jetzt nicht	Sonstiges
+UGV-1	Moment mal, bitte	Sonstiges
+UGV-1	ja, hier ist der UGV 1 von Teamleader	Kontakt_Bestaetigung
+UGV-1	ich hab das Fass jetzt hier drehen können und festgestellt, dass es sich um dasselbe Piktogramm beziehungsweise den selben Piktogramme handelt, wie bei dem ersten Fass	Information_geben
+UGV-1	weiterhin, das Fass nicht beschädigt	Information_geben
+TL	kann man die Temperatur von dem Fass messen?	Information_nachfragen
+UGV-1	negativ	Absage
+TL	ich will wissen, ob die das Fass noch durch die Explosion ein Wärmebaustein ist	Information_nachfragen
+UGV-1	ich sehe ein Fass was einfach nur umgekippt ist, keine Leckage	Information_geben
+UGV-1	ich wollte jetzt mit dem UGV 1 nach oben ins Obergeschoss versuchen	Information_geben
+UGV-1	weil da wollte der Tim hin und konnte nicht weiter erkunden, wenn das okay ist	Information_geben
+UGV-1	wenn das okay ist	Information_geben
+TL	ja, versuch das mal	Zusage
+UGV-1	UGV 2 von UGV 1	Kontakt_Anfrage
+UGV-2	hört	Kontakt_Bestaetigung
+UAV	Teamleader von der UAV, kommen	Kontakt_Anfrage
+TL	Teamleader hört	Kontakt_Bestaetigung
+UAV	also, aufgrund der Wetterlage	Information_geben
+UAV	wäre jetzt ein Inspektionsflug möglich	Information_geben
+TL	ja, dann werden wir jetzt fliegen und versuchen, Bilder vor der Unfallstelle aufzunehmen	Zusage
+UAV	welcher Gebäudeteil soll umflogen werden?	Information_nachfragen
+TL	der mittlere Gebäudeteil	Information_geben
+UAV	das ist verstanden	Information_geben
+UAV	wir müssen jedoch nochmal wieder warten	Information_geben
+UAV	weil noch eine Schauerwolke durchläuft	Information_geben
+TL	ja, verstanden	Information_geben
+UAV	wir gehen automatisch in die Operation sobald der Regen nachlässt	Information_geben
+TL	Gruppe Drohne von Teamleader, kommen	Kontakt_Anfrage
+UAV	die UAV hört	Kontakt_Bestaetigung
+TL	wie sieht's aus, könnt ihr fliegen?	Information_nachfragen
+UAV	noch negativ	Absage
+UAV	im Moment ist wieder zu viel Regen	Information_geben
+TL	ja, verstanden	Information_geben
+TL	UGV 1 von Teamleader, kommen	Kontakt_Anfrage
+UGV-1	kommen Sie	Kontakt_Bestaetigung
+TL	UGV 2 erreicht?	Information_nachfragen
+UGV-1	ja, ist negativ	Absage
+UGV-1	ich bin einmal jetzt um das Gebäude rum Tim, war dat 'ne schräge Treppe	Information_geben
+UGV-2	ja, wie so 'ne Stahltreppe halt aussieht, ne biegt erst mal einer nach oben weiter konnte ich nicht sehen	Information_geben
+UGV-2	weil meine Kamera nicht höher ge-	Information_geben
+UGV-1	ja, weil ich stehe vor einer da liegt auch ein Trümmerteil davor	Information_geben
+UGV-2	es gab einmal eine Treppe, da stand 'n Schild kein Durchgang	Information_geben
+UGV-2	dann bin ich natürlich nicht hochgefahren	Information_geben
+UGV-2	und dann war die andere Treppe, war mit so 'nem weißen Geländer abgesperrt, hier	Information_geben
+UGV-2	in dem Bereich befinde ich mich	Information_geben
+UGV-1	ja, hab ich verstanden, ich guck nochmal	Information_geben
+TL	UGV 1 von Teamleader	Kontakt_Anfrage
+UGV-1	ich komm'	Kontakt_Bestaetigung
+TL	könnt ihr was erkunden, was da in lauter Rauch steht?	Information_nachfragen
+UGV-1	ja, hab ich, da müsstest ein Foto von hab'n	Information_geben
+TL	ich gucke	Information_geben
+TL	dann schick mir mal 'n Foto davon	Einsatzbefehl
+UGV-1	Teamleader von UGV 1	Kontakt_Anfrage
+UGV-1	ich hab 'nen weiteren Kanister gefunden, weiß	Information_geben
+UGV-1	werde jetzt ein Foto davon machen und dir schicken	Information_geben
+UGV-1	Tim, bist du so 'nen Gang entlang gefahren?	Information_nachfragen
+UGV-2	ja, korrekt	Zusage
+UGV-1	Teamleader von UGV 1	Kontakt_Anfrage
+TL	hört	Kontakt_Bestaetigung
+UGV-1	ja, der weiße Kanister steht aufrecht	Information_geben
+UGV-1	scheint verschlossen zu sein, ich werd ihn jetzt mal versuchen, zu drehen um eventuell 'n Piktogramm darauf zu sehen	Information_geben
+TL	ja, verstanden	Information_geben
+TL	UGV 2, wie sieht's bei euch aus? UGV 2 von Teamleader, kommen	Kontakt_Anfrage
+TL	UGV 2 von Teamleader, kommen	Kontakt_Anfrage
+UGV-2	UGV 2 gerufen?	Information_nachfragen
+TL	ja, richtig	Zusage
+TL	wie sieht's bei euch aus, geht gar nichts mehr, oder seid ihr wieder im Spiel?	Information_nachfragen
+TL	UGV 2 von Teamleader, kommen	Kontakt_Anfrage
+UGV-2	UGV 2 gerufen?	Information_nachfragen
+TL	ja, richtig	Zusage
+UGV-2	ja, mein Roboter hier, der hat jetzt ne Kette fast verloren	Information_geben
+TL	also defekt	Information_geben
+TL	UGV 1 von Teamleader, kommen	Kontakt_Anfrage
+UGV-1	ja, mir ist jetzt gelungen, das Gefäß zu bergen, beziehungsweise zu drehen	Information_geben
+UGV-1	werd jetzt einmal ne Rundumschau von dem Gefäß machen	Information_geben
+UGV-1	ich schick' dir aber erst nochmal 'n Foto	Information_geben
+UGV-1	beim wenden des Gefäßes ist ein leichter flüssiger Stoff ausgetreten	Information_geben
+UGV-1	aber nur ein Spritzer	Information_geben
+UGV-1	keine Gefahr	Information_geben
+UGV-1	Teamleader von UGV 1	Kontakt_Anfrage
+TL	Teamleader hört	Kontakt_Bestaetigung
+UGV-1	ja, der Kanister wurde jetzt von allen Seiten begutachtet, Kanister ist verschlossen keine Gefahr und Piktogramme auf dem Kanister	Information_geben
+UGV-1	ich beweg' mich weiter fort	Information_geben
+TL	ja, verstanden	Information_geben
+UGV-1	Teamleader von UGV 1	Kontakt_Anfrage
+UGV-1	ich versuche jetzt zur UGV 2 zu kommen	Information_geben
+TL	ja, verstanden	Information_geben
+TL	was ist mit der Drohne? Teamleader, kommen	Kontakt_Anfrage
+UAV	die UAV hört	Kontakt_Bestaetigung
+TL	ja, UAV, wie sieht's aus, könnt ihr fliegen?	Information_nachfragen
+UAV	ne, leider immer noch nicht	Absage
+UAV	es regnet zu sehr	Information_geben
+TL	ja, verstanden	Information_geben
+UAV	Teamleader von UAV, kommen	Kontakt_Anfrage
+UAV	Teamleader von UAV, kommen	Kontakt_Anfrage
+TL	hört	Kontakt_Bestaetigung
+UAV	wir sind mit der Drohne jetzt in der Luft und werden hinter das Gebäude fliegen	Information_geben
+TL	ja, verstanden	Information_geben
+TL	UAV 1 habt ihr das Ziel erreicht?	Information_nachfragen
+UGV-1	also, ich hab den UAV 2 getroffen kann da aber mich nicht weiter	Information_geben
+UGV-1	aber ich seh' jetzt wieder 'ne Rauchentwicklung	Information_geben
+TL	ja, verstanden	Information_geben
+TL	UAV Drohne?	Kontakt_Anfrage
+UAV	die Drohne hört	Kontakt_Bestaetigung
+UAV	wir haben auch gerade mal zwei Bilder gemacht	Information_geben
+UAV	die Rauchentwicklung kommt neben dem Hochofen zustande	Information_geben
+TL	UAV Drohne	Kontakt_Anfrage
+TL	kann man von oben vielleicht mir ein Foto schicken?	Einsatzbefehl
+UAV	wir haben ein Foto geschickt	Zusage
+UAV	wir schalten jetzt mal auf Infrarot, um zu gucken, ob wir irgendwo eine thermische Entwicklung erkennen können	Information_geben
+TL	ja, verstanden	Information_geben
+UAV	Teamleader -	Kontakt_Anfrage
+UGV-1	UAV 1 von UGV 1	Kontakt_Anfrage
+UGV-1	UAV 1 von UGV 1	Kontakt_Anfrage
+UGV-1	Drohne von UGV 1	Kontakt_Anfrage
+UAV	die Drohne hört	Kontakt_Bestaetigung
+UGV-1	kannst du mir nochmal ein bisschen näher beschreiben, wo die Rauchentwicklung ist?	Information_nachfragen
+UAV	ich hab' gerade Schwierigkeiten	Information_geben
+UAV	weil ich seh' dich auf dem anderen Bild gerade nicht	Information_geben
+UAV	du kannst aber in die Bilderbox gucken, da müsstest du eigentlich das Bild aus Sichtweise der Drohne sehen	Information_geben
+UGV-1	Teamleader von UGV 1	Kontakt_Anfrage
+TL	Teamleader hört	Kontakt_Bestaetigung
+UGV-1	ja, ich komme nicht weiter höher ins Obergeschoss ohne dass ich eine Absperrung durchfahre	Information_geben
+TL	ja, fahren Sie wieder zurück ins Untergeschoss	Einsatzbefehl
+TL	UGV Drohne von Teamleader, kommen	Kontakt_Anfrage
+UAV	UAV hört	Kontakt_Bestaetigung
+TL	noch ein Bild schicken, und das aber mit einem Schwarz-Weiß-Hintergrund	Einsatzbefehl
+UAV	machen wir dir fertig	Zusage
+UGV-1	Teamleader von UGV 1	Kontakt_Anfrage
+UGV-1	hast du mittlerweile den blauen Kanister gesehen	Information_nachfragen
+UGV-1	weil ich komm da gerade nochmal vorbei	Information_geben
+UGV-1	könnt ich ein neues Foto machen	Information_geben
+TL	ja, schick ich jetzt den Angriff dorthin zum Lesen	Information_geben
+TL	aber wenn du direkt vorbeikommst, dann mach nur ein näheres Foto als Nachweis	Zusage
+UAV	Teamleader von UAV	Kontakt_Anfrage
+UAV	wir haben ein neues Live-Bild, neue Rauchentwicklung in dem hinteren Bereich	Information_geben
+TL	ja, verstanden	Information_geben
+TL	schicken Sie mir das Foto?	Einsatzbefehl
+UAV	schon da	Zusage
+TL	UAV Drohne	Kontakt_Anfrage
+UAV	UAV hört	Kontakt_Bestaetigung
+UAV	aber ich hab nochmal ein Bild hinterher geschickt	Information_geben
+UAV	die Rauchentwicklung, die verringert sich zwischenzeitlich immer wieder	Information_geben
+UAV	es ist aber auch sehr schwierig,  genaue Bilder zu erkennen	Information_geben
+UAV	aufgrund des Windes, weil die Drohne noch sehr stark hin und her schwankt	Information_geben
+TL	ja, verstanden	Information_geben
+UAV	Teamleader von der UAV Drohne	Kontakt_Anfrage
+TL	hört	Kontakt_Bestaetigung
+UGV-1	wir machen jetzt erst mal noch eine Zwischenlandung für einen Akkuwechsel	Information_geben
+TL	ja, verstanden	Information_geben
+TL	UAV 1 von Teamleader, kommen	Kontakt_Anfrage
+UAV	UAV hört	Kontakt_Bestaetigung
+TL	hattest du von dem blauen Kanister noch ein Foto gemacht?	Information_nachfragen
+UGV-1	ich bin gerade dabei	Information_geben
+TL	verstanden	Information_geben
+TL	Teamleader an alle	Kontakt_Anfrage
+TL	Übung beendet	Information_geben
+TL	alle bitte hier zum Treffpunkt ans Zelt kommen	Einsatzbefehl
+TL	Der Radio Check	Information_geben
+TL	UGV-1 für Einsatzleiter	Kontakt_Anfrage
+UGV-1	Ja ich kann dich hören	Kontakt_Bestaetigung
+TL	UGV-2	Kontakt_Anfrage
+UGV-2	UGV-2 hört dich auch	Kontakt_Bestaetigung
+TL	Wenn ihr gleich vorgeht bitte meldet mir die üblichen Gefahren an der Einsatzstelle, Feuer, Opfer	Einsatzbefehl
+TL	Macht bitte Fotos von Positionen die euch blöd vorkommen oder interessant vorkommen	Einsatzbefehl
+TL	UGV-1 für Einsatzleiter	Kontakt_Anfrage
+TL	Bitte mach mir mal ein Foto von deinem Standort kommen	Einsatzbefehl
+TL	Ich seh euch gleich am Eingang der Halle	Information_geben
+UGV-1	Okay ja	Zusage
+UGV-1	Ich hab dir jetzt ein Foto von meinem Blickfeld geschickt	Information_geben
+UGV-1	Es befindet sich schon mal links ein Gefahrgutfass Ölfass	Information_geben
+UGV-1	Dort auch senden?	Information_nachfragen
+TL	Also sieht so aus als hätte gerade ich gar keine Connection zur Database	Information_geben
+TL	Also beschreibe mir einfach wo du stehst	Information_nachfragen
+UGV-1	Ich bestehe an einem Gang am Anfang der Halle Eingang	Information_geben
+UGV-1	Blickrichtung kann ich dir jetzt nicht sagen	Information_geben
+UGV-1	Rechts von mir sehe ich den Ölfass	Information_geben
+UGV-1	Ich denke also ich denke das ist ein Ölfass ich weiß nicht genau was drin ist übliches Rundfass	Information_geben
+UGV-1	Ich würde jetzt einfach geradeaus fahren und schauen was ich so weiter finde	Information_geben
+UGV-1	Kommen	Kontakt_Anfrage
+TL	Verstanden	Zusage
+TL	Einsatzauftrag du fährst den langen Gang entlang ich gehe mal davon aus dass es am südlichen Wand der Halle ist und bleibst bitte auf der Ebene	Einsatzbefehl
+TL	Wenn du hoch oder runterfährst sagst mir bitte vorher Bescheid	Einsatzbefehl
+TL	Kommen	Kontakt_Anfrage
+UGV-2	UGV-2 hört dich	Kontakt_Bestaetigung
+TL	Frage kannst du den anderen Roboter sehen?	Information_nachfragen
+UGV-2	Ich seh einen Roboter aber das wird aufgrund der Beschreibung nicht der Roboter sein	Absage
+TL	Verstanden	Information_geben
+TL	Okay	Information_geben
+TL	Einsatzauftrag für dich du fährst weiter in die Halle rein und suchst nach dem Zugang mit dem du dich weiter nach Osten entwickeln kannst	Einsatzbefehl
+TL	Kommen	Kontakt_Anfrage
+UGV-2	Ja das ist so verstanden Ich fahr weiter Richtung Norden in die Halle rein und suche mir einen Zugang in Richtung Osten	Zusage
+TL	Okay	Information_geben
+TL	Einsatzleitung für beide Roboter	Kontakt_Anfrage
+TL	Ich habe jetzt wieder Connection zur Datenbank	Information_geben
+TL	Ihr könnt also Fotos schicken	Information_geben
+TL	ich sehe auch eure Position live	Information_geben
+UGV-1	Ja Teamleader von UGV-1 kommen	Kontakt_Anfrage
+TL	Höre	Kontakt_Bestaetigung
+UGV-1	Kannst du denn mein Foto empfangen das ich gerade geteilt habe?	Information_nachfragen
+TL	Hey ja	Zusage
+TL	Ich sehe dass die Fotos geadded wurden ich seh sie noch nicht auf der Karte	Information_geben
+TL	Geh einfach weiter vor wir versuchen das Problem hier zu lösen	Einsatzbefehl
+UGV-1	Teamleader von UT-1 kommen	Kontakt_Anfrage
+TL	Höre	Kontakt_Bestaetigung
+UGV-1	Ja ich gehe jetzt rechter Hand	Information_geben
+TL	UGV-2 für Einsatzleiter kommen	Kontakt_Anfrage
+UGV-2	UGV-2	Kontakt_Bestaetigung
+TL	Kannst du mir mal ein Foto von deiner Position machen?	Einsatzbefehl
+UGV-2	Ja ich mach dir mal ein Snapshot	Zusage
+UGV-2	Ist das bei dir angekommen?	Information_nachfragen
+TL	Ja	Zusage
+TL	das braucht mal paar Sekunden	Information_geben
+UGV-1	Ja Teamleader von UGV-1 kommen	Kontakt_Anfrage
+TL	Höre	Kontakt_Bestaetigung
+UGV-1	Ja ich werd jetzt rechts abbiegen	Information_geben
+UGV-1	Rechtseitig ein blaues Fass mit ner undefinierten Aufschrift gefunden	Information_geben
+UGV-1	Hab dir ein Foto gemacht geteilt	Information_geben
+UGV-1	kommen	Kontakt_Anfrage
+TL	Ja	Kontakt_Bestaetigung
+TL	verstanden	Information_geben
+TL	UGV-1	Kontakt_Anfrage
+TL	Kannst du mal abschätzen wie weit du bis jetzt gefahren bist?	Information_nachfragen
+TL	Deine Position auf meiner Karte hat sich kaum geändert	Information_geben
+UGV-1	Ja ich denke so 5-6 meter weiter bin ich noch nicht gekommen kommen	Information_geben
+TL	Verstanden	Information_geben
+TL	UGV-2 für Einsatzleiter	Kontakt_Anfrage
+UGV-2	UGV-2	Kontakt_Bestaetigung
+TL	Hat das mit dem Foto geklappt?	Information_nachfragen
+TL	Bei mir ist nichts angekommen	Information_geben
+UGV-2	Also bei mir sind zwei Fotos auf der Karte hinterlegt	Zusage
+UGV-2	Die müssten auch ungefähr von meiner Position gekommen sein	Information_geben
+TL	UGV-2 ich krieg deine Daten immer noch nicht	Information_geben
+TL	Kannst du mir mal grob deine Position auf der Karte durchgeben?	Einsatzbefehl
+TL	Ja okay verstanden	Information_geben
+UGV-1	I lost the connection to the TDF	Information_geben
+UGV-1	Teamleader von UGV-1 kommen	Kontakt_Anfrage
+TL	Höre	Kontakt_Bestaetigung
+UGV-1	Ja mein TDS muss neu gestartet werden	Information_geben
+TL	Ja verstanden	Information_geben
+TL	Gib mir Bescheid wenn du weiterfährst	Einsatzbefehl
+UGV-2	Teamleader von UGV-2	Kontakt_Anfrage
+TL	Teamleader	Kontakt_Bestaetigung
+UGV-2	Ja also ich hab gerade jetzt hier ein blaues Fass gefunden	Information_geben
+	so ein übliches Chemikalienfass	Information_geben
+TL	Ja verstanden	Information_geben
+TL	Wie ist der Zustand des Fasses?	Information_nachfragen
+UGV-2	Steht senkrecht und sieht auf dem ersten Blick heil aus keine Lache oder so was drumherum	Information_geben
+TL	Ja verstanden	Information_geben
+TL	Dann Foto machen	Einsatzbefehl
+TL	Und dann weiter vorgehen	Einsatzbefehl
+UGV-1	Teamleader von UGV-1 kommen	Kontakt_Anfrage
+TL	Höre	Kontakt_Bestaetigung
+UGV-1	Ja ich kann hier weiterfahren	Information_geben
+TL	Ja verstanden	Information_geben
+TL	Gib mir bitte nochmal ein Foto von deiner Fahrtrichtung	Einsatzbefehl
+UGV-1	Teamleader von UGV-1 kommen	Kontakt_Anfrage
+TL	UGV-1 UGV-2 und UAV kommen	Kontakt_Anfrage
+UAV	UAV hört	Kontakt_Bestaetigung
+UGV-1	UGV-1 hört	Kontakt_Bestaetigung
+UGV-2	UGV-2	Kontakt_Bestaetigung
+UAV	UAV	Kontakt_Bestaetigung
+TL	So weiteren Einsatzauftrag erhalten folgende Lage grundsätlich die Lage die selbe wie heute morgen Explosion in diesem länglichen Gebäude unklare Ausdehnung	Information_geben
+TL	Jetzt neuer Bericht von Gasgeruch in der Mitte des Gebäudes	Information_geben
+TL	Unsereines Auftrag Gasquelle lokalisieren	Einsatzbefehl
+TL	Und weiter mappen	Einsatzbefehl
+TL	UAV von Einsatzleiter	Kontakt_Anfrage
+UAV	UAV hört	Kontakt_Bestaetigung
+TL	Dein Standort ist Position ECO richtig?	Information_nachfragen
+UAV	Mein Standard ist im Moment Position ECO	Zusage
+UAV	Aber du wirst keine Updates kriegen	Information_geben
+TL	Ja soweit verstanden	Information_geben
+TL	Einsatzauftrag bitte aufsteigen Übersichtsfoto machen wenn möglich aus allen vier Himmelsrichtungen	Einsatzbefehl
+TL	kommen	Kontakt_Anfrage
+UAV	Verstanden	Zusage
+TL	UGV-1 für Einsatzleiter	Kontakt_Anfrage
+TL	Du machst mir jetzt ein Foto dann gucken wir	Einsatzbefehl
+TL	Verstanden?	Information_nachfragen
+UGV-1	Ja verstanden	Zusage
+TL	UGV-2 für Einsatzleiter mitgehört?	Information_nachfragen
+UGV-2	UGV-2 mitgehört	Zusage
+UGV-2	kriegst auch ein Foto	Information_geben
+UGV-1	Teamleader von UGV-1 kommen	Kontakt_Anfrage
+TL	Höre	Kontakt_Bestaetigung
+UGV-1	Ja soll ich mal losfahren dem Tango hinterher quasi?	Information_nachfragen
+TL	Wer fährt denn da schon?	Information_nachfragen
+UGV-2	UGV-2 hat sich nur ein meter fortbewegt	Information_geben
+	damit UGV-1 da weg kommt	Information_geben
+TL	Okay	Information_geben
+TL	Also ich seh euch beide ihr steht beide am Eingang des Ganges hintereinander	Information_geben
+TL	Und jetzt fahrt ihr beide hintereinander her zum Punkt ASA 325 - 352 danke	Einsatzbefehl
+UGV-2	UGV-2 verstanden	Zusage
+TL	UGV-1 für Einsatzleiter	Kontakt_Anfrage
+UGV-2	Hier UGV-2	Kontakt_Anfrage
+UGV-2	UGV-1 kriegt da noch eine Einweisung	Information_geben
+UGV-2	Teamleiter von UGV-2	Kontakt_Anfrage
+UGV-2	Du müsstest ein Bild gekriegt haben ASA 352 müsste rechts von mir von meiner Position auf dem Bild sein	Information_geben
+TL	Ja verstanden	Information_geben
+TL	Nimm doch mal bitte einen Rundblick	Einsatzbefehl
+TL	Wenn du da nichts entdeckst weiter Richtung Osten	Einsatzbefehl
+UGV-2	Ja ist verstanden	Zusage
+UGV-2	Teamleiter von UGV-2	Kontakt_Anfrage
+TL	Höre	Kontakt_Bestaetigung
+UGV-2	Gucke dir mal das Bild an was gerade gekommen ist das ist rechts von meiner Position	Information_geben
+UGV-2	Ergeht irgendwie so eine Plattform mit so einer Metallbox auf Palette	Information_geben
+TL	Ja ich gucke	Zusage
+TL	UGV-2 von Einsatzleiter	Kontakt_Anfrage
+TL	Guck dir das mal genauer an bitte wenn du da hochkommst	Einsatzbefehl
+UGV-2	Ja das ist verstanden	Zusage
+UGV-2	Ich versuch das mal	Zusage

--- a/original_finetuning_for_intents/data_iso/dev.tsv
+++ b/original_finetuning_for_intents/data_iso/dev.tsv
@@ -1,0 +1,183 @@
+TL	jo	Auto-positive
+TL	ja, hab ich verstanden	Auto-positive
+UAV	die Drohne ist gelandet wir reparieren	Inform
+UAV	Teamleader -	TurnAssign
+TL	Operator 1 für Teamleader, kommen	TurnAssign
+TL	Frage: wo ist euer Standort inzwischen?	SetQuestion
+TL	benötige Foto	Request
+TL	wiederholen	Request
+UAV	Ja ich habe da ich keine GPS Daten	Answer
+TL	UGV 1, UGV 2, kommen	TurnAssign
+TL	ja, verstanden	Auto-positive
+UGV-1	ja, richtig so	Confirm
+TL	Der Radio Check	InteractionStructuring
+UAV	Teamleader von UAV	TurnTake
+TL	Kannst du dich in die Richtung zurückbegeben und da mal nachgucken	Request
+UAV	UAV hat Bilder in westlicher Blickrichtung verfügbar	Inform
+TL	Ja die UAV hat berichtet dass es eine Rauchentwicklung gibt aus dem Hallentorbogen wo unser Startpunt ist	Inform
+UAV	wir gehen automatisch in die Operation sobald der Regen nachlässt	Promise
+TL	Hat das mit dem Foto geklappt? Bei mir ist nichts angekommen	Question
+UAV	wir gehen runter zur Landung, Akkutausch	Inform
+UAV	UAV Operator hört	TurnAccept
+TL	hör' dich	TurnAccept
+UGV-2	hört	TurnAccept
+UGV-2	Hier UGV-2	TurnAccept
+UGV-2	Steht senkrecht und sieht auf dem ersten Blick heil aus keine Lache oder so was drumherum	Answer
+UGV-2	UGV 2 hört	TurnAccept
+UGV-1	wir haben auch jetzt hier erhöhte Rauchentwicklung	Inform
+TL	UGV 1 von Einsatzleiter	TurnAssign
+UGV-1	ja, ist korrekt	Confirm
+UGV-2	ja, wir sind auch einsatzbereit, versuchen noch den Standort rauszufinden	Confirm
+UGV-1	Hier ist UGV-1	TurnAccept
+UGV-1	Teamleader von UGV 1	TurnAssign
+UGV-2	Teamleader von UGV 2	TurnAssign
+TL	ja, das zweite Fass ist liegt auf dem Boden ist aber auch augenscheinlich verschlossen, läuft nichts aus, keine Flüssigkeit läuft aus	Inform
+TL	warten	Pausing
+TL	ich höre	TurnAccept
+TL	ja, das ist verstanden	Auto-positive
+TL	ja	AcceptOffer
+UGV-1	Kannst du uns zur nördlichen Gebäudewand?	Question
+TL	Dirk kommen	TurnAccept
+TL	ist das welcher Hochofen ist es, der rechte oder der linke von uns aus gesehen?	ChoiceQuestion
+UGV-2	Einsatzleiter von UGV 2, kommen	TurnAssign
+UGV-2	Ja ich mach dir mal ein Snapshot	AcceptRequest
+TL	gehe davon aus das ist trotzdem die liegende Person ist die wir suchen und finden sollten	Inform
+UGV-1	hast du mittlerweile den blauen Kanister gesehen, weil ich komm da gerade nochmal vorbei, könnt ich ein neues Foto machen	PropositionalQuestion
+TL	Bild hast du verschickt?	CheckQuestion
+UGV-2	hier liegt ein grünes Fass, und es ist starke Rauchentwicklung zu erkennen	Inform
+TL	also haben wir insgesamt vier Personen im Gefahrenbereich?	PropositionalQuestion
+UGV-2	ja, mach ich	AcceptRequest
+TL	ich höre	TurnAccept
+UAV	Leider kann ich nicht sehen welches die Fotonummern sind	Inform
+TL	Und mach sozusagen mal ein Rundumfoto das heißt aus den anderen beiden Himmelsrichtungen auch noch	Request
+UGV-2	hab dir ein Bild gemacht und geteilt	Inform
+UAV	Hier ist ein recht guter Überblick kommen von der Halle vielleicht hilft das zu	Inform
+UGV-1	das ist korrekt	Confirm
+UAV	Einsatzleiter von UAV	TurnAssign
+TL	habt ihr schon neue Erkenntnisse?	PropositionalQuestion
+TL	Operator 1 für Teamleader, kommen	TurnAssign
+TL	ja, verstanden	AcceptOffer
+UGV-2	und ich hab Probleme den zu bewegen weil die Kameras auch nicht so funktionieren wie sie sollten	Inform
+TL	ja verstanden	Auto-positive
+TL	UGV-2 für Einsatzleiter kommen	TurnAssign
+UGV-1	Ja ich hab mich hier erst weiter nach vorne bewegt	Answer
+UGV-2	ne, ich mache hier gar nichts gerade am Rechner	Disconfirm
+TL	UAV dann bitte starten Live-Monitoring guck mal ob du da weitere Rauchentwicklungen finden kannst	Request
+UGV-2	UGV 2 hört	TurnAccept
+UGV-2	Operator 2 hört	TurnAccept
+UGV-1	Werde weiter geradeaus erkunden kommen	Offer
+TL	ich höre	TurnAccept
+UAV	Dirk hört	TurnAccept
+TL	Ja ich hab sie gefunden sie sind in Sankt Augustin	Inform
+UGV-1	ich habe weiterhin eine grüne Tonne mit einer drauf befindlichen Flasche gefunden	Inform
+UGV-2	Markus von Daniel	TurnAssign
+UGV-1	UGV 1 hört	TurnAccept
+UGV-1	ja, das ist korrekt	Agreement
+UGV-2	ja, Benno für den Operator 2, kommen	TurnAssign
+TL	Andreas von Markus kommen	TurnAssign
+UGV-2	Ist das bei dir angekommen?	PropositionalQuestion
+TL	verstanden	Auto-positive
+TL	ich höre	TurnAccept
+TL	was kann in der grünen Flasche drin sein?	SetQuestion
+TL	Frage: wo ist jetzt euer Standort?	SetQuestion
+UGV-1	ich hab das Fass jetzt hier drehen können und festgestellt, dass es sich um dasselbe Piktogramm beziehungsweise den selben Piktogramme handelt, wie bei dem ersten Fass	Inform
+UGV-1	beim wenden des Gefäßes ist ein leichter flüssiger Stoff ausgetreten	Inform
+UAV	Lena hört	TurnAccept
+TL	hier Markus verstanden	Auto-positive
+TL	UGV-2 für Einsatzleiter	TurnAssign
+UGV-1	UGV-1 hört	TurnAccept
+UGV-1	Teamleader von UGV 1	TurnAssign
+TL	Hast du das letzte Foto gepublished? Ich konnte es noch nicht sehen	PropositionalQuestion
+TL	UGV-2 für Einsatzleiter	TurnAssign
+UAV	ich schick dir jetzt das Foto	Promise
+UGV-1	ja, ich höre dich	TurnAccept
+TL	wo bist du jetzt? Standort	SetQuestion
+UAV	ich habe drei geschickt	Answer
+TL	Ja verstanden	Auto-positive
+UGV-1	ja, ist verstanden	Auto-positive
+TL	also ich wiederhole wir haben vier Personen die sind gehfähig und eine weitere Person mit Warnweste auch gehfähig	Auto-positive
+UGV-1	man sieht die Rauchentwicklung und einen Behälter, das ist Blickrichtung Ost	Inform
+UGV-1	UGV 1 hört	TurnAccept
+TL	Halt deine Position	Request
+UGV-1	Richtig verstanden	Confirm
+TL	UGV-1 für Einsatzleiter	TurnAssign
+TL	ich höre	TurnAccept
+Speaker	Dialogue Turn Text	Communicative Function
+TL	Verstanden?	FeedbackElicitation
+UAV	Ja die 3D Karte ist in der Ar- in Arbeit Dauer für das Modell circa halbe Stunde komme wieder wenn Aufgabe beendet	Inform
+TL	flieg mal mit der Drohne genau in die andere Richtung	Request
+UGV-1	also, ich stehe jetzt genau vor dem Fass, ich werde nochmal ein Foto machen und dir schicken	Inform
+UAV	UAV hört	TurnAccept
+UGV-2	ja, das ist der Sven, Operator 2	Answer
+TL	wenn betriebsbereit Auftrag durchführen	Request
+UGV-1	ja, der weiße Kanister steht aufrecht	Inform
+TL	UGV-1 für Einsatzleiter	TurnAssign
+TL	also defekt	Auto-positive
+TL	Frage Standort	Question
+UGV-2	aber ich sehe gerade Rauchentwicklung von hier aus, soll ich mal ein Foto machen?	Inform
+UGV-1	ja, auf der ersten Ebene, zu den Rampen hin	Answer
+UGV-2	melde mich sofort	Pausing
+UGV-2	negativ, ich hab den Roboter mit dem Arm, dort ist keine Infrarot-Kamera vorne	Disconfirm
+UGV-2	Teamleader von UGV-2	TurnAssign
+TL	verstanden	Auto-positive
+UGV-1	das Fass wurde einmal umkreist es liegt wahrscheinlich genau darauf, ich kann mal versuchen mal es ein bisschen zu drehen	Inform
+TL	du hattest mich gerufen?	TurnAssign
+UGV-2	Eins davon ist mit dem Gefahrgutssymbol reizend das X gekennzeichnet Trader Oxyn Nummer eins	Inform
+TL	ich höre	TurnAccept
+UGV-1	westliche Richtung, verstanden	Auto-positive
+UGV-2	Teamleader, UGV 2 gerufen?	Auto-negative
+TL	UGV 1 von Teamleader	TurnAssign
+UGV-2	im ersten Obergeschoss ein grünes Fass und starke Rauchentwicklung	Inform
+UGV-2	Das könnte man ausprobieren ob man sich bewegen kann aber ich denke eher nicht	Confirm
+UGV-1	Gebäude nördliche Wand in westlicher Richtung absuchen nach Hitzequellen und vermissten Personen verstanden	AcceptRequest
+UGV-1	Ja Teamleader von UGV-1 kommen	TurnAssign
+UGV-2	Teamleiter von UGV-2	TurnAssign
+TL	Also beschreibe mir einfach wo du stehst	Request
+UGV-1	ja, Foto gemacht habe ich, ich weiß bloß nicht, ob es angekommen ist	Confirm
+TL	Verstanden	Auto-positive
+TL	Andreas und Daniel könnt ihr mir beide jeweils schon mal ein Foto von eurem aktuellen Standort senden?	Request
+UGV-1	bisher negativ	Disconfirm
+UGV-1	den Flur geradeaus durch links die Treppe rauf danach rechts abbiegen dann am Hochofen den Hochofen folgen	Answer
+UGV-1	scheint so, als läge das Fass auf dem Gefahrzettel oder ähnlich	Inform
+UAV	Benno für Lena	TurnAssign
+UGV-1	ja, das ist negativ	DeclineRequest
+UAV	wir haben zur Zeit technische Probleme und können noch keine neuen Bilder senden	Inform
+TL	ja, verstanden	AcceptOffer
+UGV-1	ja, Teamleader von UGV 1	TurnAssign
+UGV-2	ja, wir haben mittlerweile die Kontrolle gewonnen und sind jetzt auch bei UGV 1	Inform
+TL	gibt es schon irgendwelche nennenswerten Erkenntnisse?	Question
+UGV-1	Ich meine müsste Foto 300 sein kommen	Inform
+TL	hab kein Bild	Disagreement
+UGV-2	ich hab hier einen Treppenraum	Inform
+TL	kommen	TurnAccept
+UGV-1	welche rückwärtige Seite, vom Fass?	SetQuestion
+UGV-1	Ja ich gehe jetzt rechter Hand	Inform
+TL	Okay Einsatzleitung für beide Roboter	Auto-positive
+UGV-1	UGV 1 erreicht gerade die erste Ebene	Answer
+UAV	Lena hört	TurnAccept
+TL	ja, dann werden wir jetzt fliegen und versuchen, Bilder vor der Unfallstelle aufzunehmen	AcceptOffer
+TL	Kannst du mir mal ein Foto von deiner Position machen?	Request
+UGV-2	Auf dem Stuhl befinden sich zwei Pakete	Inform
+UGV-2	Daniel hört	TurnAccept
+TL	ja, klar	AcceptOffer
+UAV	der eine ist nur das Gerüst und der andere ist voll, ich meine den vollen	Answer
+UGV-1	aber ich seh' jetzt wieder 'ne Rauchentwicklung	Inform
+TL	Andreas mitgehört?	Feedback Elicitation
+TL	Daniel von Markus kommen	TurnAssign
+TL	einmal aus der Ferne und einmal aus der Nähe wenn möglich	Request
+TL	hört	TurnAccept
+TL	du sprachst eben von einer anderen Ebene habt ihr die schon erreicht?	Question
+TL	Dann bitte erneut starten und dann in östlicher Richtung erst mal fliegen	Request
+UGV-1	ja, ich hab den ersten Raum weitestgehend abgesucht, gerade so ein bisschen technische Schwierigkeiten	Inform
+UGV-2	UGV-2 verstanden	AcceptRequest
+TL	drei gehfähige Personen richtig?	CheckQuestion
+TL	ja, landet erst mal, ihr kriegt einen neuen Auftrag	Answer
+UAV	ja, das habe ich verstanden	AcceptRequest
+TL	ja, verstanden	Auto-positive
+TL	Ich habe gerade keine Connection kann dein Foto nicht sehen	Inform
+UGV-1	nur auf dem einen stehenden grünen Fass steht noch eine grüne Flasche	Inform
+TL	vorrängig weiter Personen suchen	Request
+UGV-2	und ich glaube, da kommt UGV 1 auch wieder angerollt	Inform
+UGV-2	UGV 1 ist gerade an uns vorbei gefahren, sollen wir versuchen, uns abz- anzuschließen?	Inform
+UGV-1	bis zum Opfer auf jeden Fall	Confirm
+Speaker	Dialogue Turn Text	Communicative Function

--- a/original_finetuning_for_intents/data_iso/test.tsv
+++ b/original_finetuning_for_intents/data_iso/test.tsv
@@ -1,0 +1,176 @@
+UAV	UAV hört	TurnAccept
+UGV-1	ja, ist verstanden	Auto-positive
+TL	Höre	TurnAccept
+UGV-1	Auf der linken Seite sehe ich eine Palette mit Wellen	Inform
+UAV	ja zumindest in der Nähe davon direkt neben dem Hochofen	Confirm
+UGV-1	Teamleader von UGV-1 kommen	TurnAssign
+UAV	das habe ich verstanden	AcceptRequest
+TL	Okay Einsatzauftrag für dich du fährst weiter in die Halle rein und suchst nach dem Zugang mit dem du dich weiter nach Osten entwickeln kannst Kommen	Opening
+UAV	Benno für Lena	TurnAssign
+TL	wir haben jetzt ein Trupp auf dem Weg zur verunfallten Person	Inform
+TL	Bodenroboter zwei von Markus kommen	TurnAssign
+UGV-2	Daniel verstanden	Auto-positive
+UGV-1	Teamleader von UGV-1 kommen	TurnAssign
+TL	ja, verstanden	Auto-positive
+TL	Für Sie konkreter Auftrag Sie begeben sich zur nördlichen Gebäudekante und bewegen sich dann westwärts	Request
+TL	UAV für Einsatzleiter	TurnTake
+UGV-1	Markus von Andreas kommen	TurnAssign
+UGV-2	im ersten Obergeschoss vor einem Hochofen rechtsseitig ein grünes Fass und Rauchentwicklung	Answer
+TL	ja, verstanden	Auto-positive
+UAV	negativ ich hab gerade Infrarot und diesen Kunstrauch sieht man dann nicht	DeclineRequest
+UGV-1	können wir weitermachen?	PropositionalQuestion
+UGV-1	also, ich hab den UAV 2 getroffen kann da aber mich nicht weiter	Answer
+UAV	wir müssen gleich nochmal den Akku tauschen, hast du danach noch einen Auftrag für uns?	Inform
+UGV-1	ja, hier ist der UGV 1 von Teamleader	TurnAccept
+UAV	die Drohne hört	TurnAccept
+UGV-1	Ja ich könnte jene Rauchentwicklung feststellen beziehungsweise es könnte eine Rauchentwicklung sein	Inform
+UGV-2	Direction is correct	Inform
+UAV	Ungefähr an der Position von ASA 310	Answer
+TL	Na ja das ist verstanden	Auto-positive
+TL	ja korrekt da stehen bleiben	Confirm
+UAV	ich hab dir gerade ein Übersichtsbild geschickt, da erkennt man den gefüllten - also den großen Hochofen sag mir, wo du hinmöchtest	Inform
+TL	ja verstanden	AcceptOffer
+TL	Übungsende	Inform
+UGV-2	ja, ich weiß, ich seh den Rauch ab und zu	Confirm
+TL	Ja verstanden	Auto-positive
+TL	ich höre	TurnAccept
+TL	ich möchte Infrarot-Bilder haben mit dem Ziel Leckagen festzustellen beziehungsweise Wärmestrahlung	Answer
+TL	Foto 235?	CheckQuestion
+UAV	ja, das ist schon mal gut, ja	Auto-positive
+UAV	das Bild hab ich dir zugesandt	Inform
+UGV-1	erstes Geschoss bei der Brandentwicklung	Inform
+TL	UGV Drohne von Teamleader, kommen	TurnAssign
+UGV-1	Teamleader von UGV 1	TurnAccept
+TL	hier Markus verstanden	Auto-positive
+UGV-1	ja, hab ich, da müsstest ein Foto von hab'n	Confirm
+TL	ihr bewegt euch weiter in westlicher Richtung?	CheckQuestion
+UGV-1	ja, zur Info - ich müsste mich jetzt genau zwischen beiden Hochöfen befinden	Inform
+TL	Höre	TurnAccept
+TL	Wenn ihr Fotos macht bitte gebt mir die Fotonummer ich verlier gerade jetzt ein bisschen den Überblick über die Fotos	Request
+TL	noch ein Bild schicken, und das aber mit einem Schwarz-Weiß-Hintergrund	Request
+TL	verstanden	Auto-positive
+TL	Ja okay dann machen wir mal gerade einen Neustart	Auto-positive
+UGV-2	ich schick dir nochmal einen Schnappschuss von ein bisschen weiter weg	Offer
+UGV-2	UGV 2 von Einsatzleiter	TurnAssign
+TL	dein Auftrag ist, an diesem Raum vorbei, wo der Operator 1 drin ist, und da ab da weiter zu suchen nach Menschen	Instruct
+UGV-1	Foto ist erstellt und geteilt	Inform
+TL	ja, reicht mir erst mal aus, setz die Erkundung fort	Answer
+TL	ich höre	TurnAccept
+TL	Operator 2 für Teamleader, kommen	TurnAssign
+TL	UGV, warten	Pausing
+UAV	UAV Operator hört	TurnAccept
+UGV-2	UGV 2, verstanden	Auto-positive
+TL	das heißt, du bist da rechts abgebogen, in den Raum rein, richtig?	CheckQuestion
+TL	Lena für Benno	TurnAssign
+TL	höre	TurnAccept
+UGV-2	Die müssten auch ungefähr von meiner Position gekommen sein	Inform
+TL	hier der Teamleader	TurnTake
+UAV	bisher ist das einzige	Answer
+UGV-1	ja verstanden	Auto-positive
+TL	Also ich kann das eine nicht gut erkennen	Inform
+TL	Nähere dich mal UGV-2 da sind zwei Proben die er eventuell aufnehmen muss	Request
+UAV	wir haben ein Foto geschickt, wir schalten jetzt mal auf Infrarot, um zu gucken, ob wir irgendwo eine thermische Entwicklung erkennen können	AddressRequest
+UGV-1	ja, der Operator 1 hört	TurnAccept
+TL	Teamleader	TurnAccept
+UGV-2	UGV-2	TurnAccept
+UGV-2	hier UGV 2, verstanden	Auto-positive
+TL	ich höre	TurnAccept
+TL	verstanden	Auto-positive
+TL	Teamleader hört	TurnAccept
+TL	Daniel ich hab dich verstanden	Auto-positive
+UGV-2	wir befinden uns auf einer Rampe	Answer
+UGV-1	ich korrigiere - UGV 1	SelfError
+TL	Wo laufen denn deine Fotos gerade rein in welchen dieser Container?	Question
+UGV-2	ja, da haben wir es gerade ein bisschen schwierig	Inform
+UGV-1	ja, hab ich verstanden, ich guck nochmal	Auto-positive
+UGV-1	Hab dir ein Foto gemacht geteilt kommen	Inform
+UAV	ja, ich sehe dich	Agreement
+UAV	Markus für Dirk	TurnAssign
+UGV-1	Drohne von UGV 1	TurnAssign
+UGV-2	ich schick noch mal ein aktuelles Foto von dem Eingang, vor dem ich jetzt stehe	Promise
+TL	Und dann weiter vorgehen	Request
+UGV-1	ja, ist verstanden	AcceptRequest
+UAV	ja	Confirm
+TL	ist bis dahin gefahrlosen Einsatz von Einsatzkräften möglich?	PropositionalQuestion
+UAV	Verstanden	Auto-positive
+UGV-2	Bisschen rissige Säulen aber es wird halten Überdimensionierung	Answer
+UGV-1	ja, positiv, wird gemacht	AcceptRequest
+TL	UAV für Teamleader	TurnAssign
+TL	wie weit seid ihr?	SetQuestion
+TL	ich seh dich auf dem Bildschirm	Inform
+UGV-1	Kannst du denn mein Foto empfangen das ich gerade geteilt habe?	PropositionalQuestion
+UGV-1	Ja hab mich jetzt nach Süden gewandt sehe jetzt in erster Linie keine Möglichkeit auf dem anderem Wege zurückzukommen	DeclineRequest
+TL	UGV-2 von Einsatzleiter	TurnAssign
+UGV-1	ich breche dann die Erkundung in östlicher Richtung ab	Inform
+TL	Andreas kommen	TurnAccept
+UAV	negativ	Disconfirm
+UGV-2	UGV 2 hört	TurnAccept
+UGV-1	dann finden sie die Person	Answer
+TL	was ist mit der Drohne? Teamleader, kommen	TurnAssign
+TL	prima	Auto-positive
+TL	verstanden	Auto-positive
+UAV	Ja zur Erkundung von Rauchquellen Personen	AcceptRequest
+TL	das ist verstanden	Auto-positive
+TL	könnt ihr mir Näheres zu dem Behälter geben?	Request
+TL	Dirk kommen	TurnAccept
+UGV-1	meine Kamera die Realbild-Kamera ist ausgefallen	DeclineRequest
+UGV-2	ja verstanden	AcceptRequest
+UGV-1	ob ein Medium ausläuft kann ich dir aktuell nicht sagen	Answer
+UAV	ich hab dir jetzt zwei Bilder geschickt, eine Detailaufnahme	Inform
+TL	Ja der Einsatzleiter an alle	Auto-positive
+UGV-2	korrekt	Confirm
+UAV	Bild ist draußen, ich hab's geteilt	Confirm
+UGV-1	ja, ist verstanden	AcceptOffer
+TL	verstanden	Auto-positive
+TL	Teamleader, verstanden	Auto-positive
+TL	In erster Linie suchen wir nach Verletzten	Request
+UAV	Teamleader von UAV operator kommen	TurnAssign
+UAV	Hier UAV operator	TurnAccept
+UAV	ich kann dir gerne weitere Bilder zukommen lassen	Offer
+UGV-2	Roboter hat zwei komplette Aussetzer funktionert dann gar nicht	Inform
+UAV	das Bild gerade würde ich ganz klar als Person einstufen	Inform
+UGV-1	ich versuche jetzt noch von dem liegenden Fass die UN-Nummer rauszu'kommen, was ich bereits schon gedreht hab was ich 	Promise
+UGV-1	ja okay, dann müsste ich dich ja sehen, der steht ja vor die Nebelmaschine?	Inform
+TL	hast du eine Möglichkeit, dass Fass näher zu identifizieren, was da drin ist?	Request
+TL	Aber auch Hitzequellen Rauchquellen oder chemische Substanzen melden und auf der Karte markieren	Request
+UAV	Einsatzleiter von UAV	TurnAssign
+TL	ja, mache ich	AcceptSuggestion
+TL	wir machen jetzt mal einen Schnitt in der Zeit mache ich eine Übergabe	Inform
+TL	Roboter 1 von Thorsten kommen	TurnAssign
+UGV-1	Andreas verstanden	Auto-positive
+UAV	die Drohne landet wir müssen Akku tauschen	Inform
+TL	ich höre	TurnAccept
+UAV	ja, das ist korrekt	Confirm
+UAV	Markus für Dirk	TurnAssign
+UAV	ja, das habe ich verstanden	AcceptRequest
+UGV-1	UGV-1 hört	TurnAccept
+TL	einmal eine Rundumsicht	Request
+UAV	Markus für Dirk	TurnAssign
+UAV	dann ein weiteres Bild einer Person oberhalb von den anderen erkenntlich an der Warnweste 	Inform
+UGV-1	ich schick' dir aber erst nochmal 'n Foto	Promise
+UAV	die Drohne startet jetzt	Inform
+UGV-1	der ist in Sichtweite zu dem blauen Kanister	Inform
+UGV-2	und ich bin auf dem Weg zum Roboter 1	Inform
+TL	dort mit dem Roboter hinfahren und mit der Menschensuche beginnen	Request
+UGV-1	negativ	Disconfirm
+TL	ich möchte mal, dass du mit der - mit der Drohne jetzt weiter fliegst zum anderen Hochofen, quasi von der anderen Seite der Einsatzstelle aus Fotos machst	Request
+UGV-1	hier der Operator 1	TurnAccept
+UAV	hier Roboter 1 kommen	TurnAccept
+TL	Auftrag für dich geradeaus die Treppe hochfahren, 50 meter rein, linksseitig dichte Rauchentwicklung	Instruct
+TL	UGV 2 von Einsatzleiter	TurnAssign
+TL	von dem Fass?	CheckQuestion
+UGV-2	na ja gut, dann mach du ein Foto von dem Fass und ich drehe um und erkunde die andere Seite	Suggestion
+TL	UGV 1	TurnAssign
+TL	ich höre	TurnAccept
+UGV-1	Ja ich versuch die Probeentnahmen zu fotografieren	AddressRequest
+UGV-1	Teamleader von UGV 1	TurnAssign
+UGV-1	ja, das kann ich machen	AcceptRequest
+UGV-1	beide Verschluss-Stopfen sind fest verschlossen	Inform
+TL	Operator 2, wie ist dein Standort?	SetQuestion
+TL	Wer fährt denn da schon?	SetQuestion
+UGV-1	ich kann höchstens so fotografieren, dass ich halt den Hochofen drauf hab'	AddressRequest
+UAV	das ist verstanden	Auto-positive
+TL	Höre	TurnAccept
+UGV-2	ja, verstanden, erkunden in südlicher Richtung	AcceptRequest
+UGV-2	Roboter 2 hört	TurnAccept
+UAV	Einsatzführer von UAV	TurnAssign

--- a/original_finetuning_for_intents/data_iso/train.tsv
+++ b/original_finetuning_for_intents/data_iso/train.tsv
@@ -1,0 +1,1439 @@
+TL	ja, schick ich jetzt den Angriff dorthin zum Lesen, aber wenn du direkt vorbeikommst, dann mach nur ein näheres Foto als Nachweis	Promise
+UGV-1	Kann ich dir nicht genau sagen	Answer
+UGV-1	keine Thermik	Disconfirm
+UGV-1	nur die Person steht jetzt	Inform
+TL	Wenn du hoch oder runterfährst sagst mir bitte vorher Bescheid Kommen	Request
+UGV-1	der weitere der steht war die Person die vorhin gelegen hat optischen Augenscheins nach	Inform
+UAV	wir haben auf der Rückseite - also aus nördlicher Sicht an der Rauchentwicklung ein Objekt festgestellt, wir können keine Gefahrstoff-Kennzeichnung erkennen	Inform
+UGV-1	werde aber jetzt auch mal die rückwärtige Seite des Fasses erkunden	Offer
+UGV-2	ja, korrekt	Confirm
+TL	guck mal auch nebenbei so ein bisschen nach dem Feuer	Request
+TL	ja, verstanden	Auto-positive
+UAV	ich schi- versuch, dir nochmal die Bilder zu schicken	SelfCorrection
+TL	Ja ist verstanden	Auto-positive
+TL	Höre	TurnAccept
+TL	Frage wie sieht's da mit der Brandausbreitung aus?	Question
+TL	zwei Minuten Funkstille zwecks Übergabe	Inform
+UGV-2	ich glaube nicht	Disconfirm
+UGV-2	UGV 2 hört	TurnAccept
+TL	das ist verstanden	Auto-positive
+UGV-1	ja, ich bin ein bisschen näher an den gefundenen - an den zweiten gefundenen Behälter rangefahren	Inform
+TL	UGV 2 von Teamleader, kommen	TurnAssign
+UGV-1	grüne Fass mit Flasche drauf	Inform
+TL	schickst du mir dann auch von da mal ein Foto?	Request
+TL	so, UAV one über den Benno kommen	TurnAssign
+UGV-2	UGV 2 gerufen?	TurnAccept
+TL	Frage ist die Drohne noch in der Luft?	PropositionalQuestion
+UAV	Ich hab weiter	Answer
+UGV-1	Dann mag es so sein	Agreement
+TL	Ja dann Missionsende für Sie	Auto-positive
+UGV-1	ich setze Personensuche fort	Offer
+TL	ja, ist bei mir angekommen	Confirm
+UGV-1	ich werde jetzt auch einen Weg suchen, ins Obergeschoss zu kommen	Offer
+TL	bin - ich - k- kann da noch nichts lokalisieren, auch anhand der großen Karte, wo genau diese Personen sich befinden	Stalling
+TL	UGV 2 von Einsatzleiter, kommen	TurnAssign
+TL	ja kann die Daten auswerten	Promise
+UAV	Teamleader von der UAV Drohne	TurnAssign
+TL	verstanden	Auto-positive
+UGV-1	ich hab jetzt nochmal ein Foto gesendet wo man das auch seiteliegende Fass und den blauen Kanister so im rückwärtigen Bereich erkennen kann, da musst du genau hingucken	Inform
+UAV	Benno für Lena	TurnAssign
+TL	Aussetzung von Thermik?	Question
+TL	UGV 1 von Teamleader, kommen	TurnAssign
+TL	UGV-1 von Einsatzleitung	TurnAssign
+TL	ich höre	TurnAccept
+UGV-2	hört	TurnAccept
+UGV-2	Frage: sollen wir da jetzt reinfahren?	Offer
+UGV-2	UGV-2 mitgehört kriegst auch ein Foto	Auto-positive
+UGV-1	Aber kann da nicht näher erkunden da da ein Geländer im Weg ist kommen	Inform
+TL	verstanden	Auto-positive
+TL	benötige Luftbild mit möglichst der leblosen Person die auf dem Wärmescan den ich hier habe zu sehen ist	Request
+UGV-1	Ich denke also ich denke das ist ein Ölfass ich weiß nicht genau was drin ist übliches Rundfass	Inform
+UGV-1	also - ich bin jetzt oben im ersten Raum, auch hier ist der Angriffstrupp nicht vorzufinden	Inform
+TL	ja verstanden	Auto-positive
+TL	UAV Operator für Teamleader, kommen	TurnAssign
+UAV	Markus für Dirk kommen	TurnAssign
+TL	ja, verstanden	Auto-positive
+UGV-2	Einsatzleiter von UGV 2, kommen	TurnAssign
+UGV-1	ja, ich fahr' gerade näher	Confirm
+TL	schauen Sie mal im Umkreis ob dort Rettungskräfte sich bewegen kommen	Request
+TL	könnt ihr den Bereich mal abschwenken mit der Kamera, und nach eventuellen Brandnestern suchen?	Request
+TL	ja, ich höre	TurnAccept
+UGV-1	Ja my robot is lost	Inform
+TL	Dirk kommen	TurnAccept
+UGV-2	negativ	Disconfirm
+TL	Ja soweit verstanden	Auto-positive
+TL	hier Markus an alle Operator	TurnTake
+UGV-1	soll ich an diesen Standort stehen bleiben?	PropositionalQuestion
+UAV	UAV Operator hört	TurnAccept
+UAV	UAV hat Softwareprobleme wir versuchen es zu beheben	Inform
+UGV-2	Einsatzleiter von UGV 2	TurnAssign
+UAV	ich habe Rauch gefunden, und weitere Personen	Inform
+UGV-1	hier Andreas kommen	TurnAccept
+UAV	Wir haben da wahrscheinlich dann Probleme mit der Datenverbindung	Inform
+UAV	wobei wir jetzt nur westlich gesucht haben, von meinem Standpunkt aus	Inform
+UAV	ich hab' gerade Schwierigkeiten, weil ich seh' dich auf dem anderen Bild gerade nicht du kannst aber in die Bilderbox gucken, da müsstest du eigentlich das Bild aus Sichtweise der Drohne sehen	AddressRequest
+TL	Ja verstanden	Auto-positive
+TL	ja, fahrt da mal rein	AcceptOffer
+UGV-1	Ja soll ich mal losfahren dem Tango hinterher quasi?	Offer
+TL	UGV 1 von Teamleader, kommen	TurnAssign
+UGV-1	ist negativ, noch nicht	Disconfirm
+UGV-1	ja verstanden ich suche weiter	AcceptRequest
+TL	Übungsende	Inform
+TL	zur Lage Menschenrettung durchgeführt und abgeschlossen	Inform
+UGV-1	Andreas hat verstanden	Auto-positive
+UGV-2	der Roboter ist momentan wieder ausgesetzt kann sich also gar nicht bewegen	Inform
+UGV-2	ja, ich rolle auch schon	Confirm
+UGV-2	hört	TurnAccept
+TL	ja, verstanden	Auto-positive
+TL	warten	Pausing
+TL	dann schick mir mal 'n Foto davon	Request
+UGV-2	Ja ich versuchte ihn gerade in den Behälter zu setzen aber irgendwie hat er sich aufgehangen	Confirm
+UAV	Einsatzleiter von UAV	TurnAssign
+UAV	ja, ich hätte jetzt einmal ein Luftbild von oben, einmal eins zu Übersicht, das schicke ich dir jetzt	Inform
+TL	Frage: Einsatzbereitschaft?	Question
+UGV-1	ja, das erste Bild hab ich dir gerade schon gesch-	Inform
+TL	einen Augenblick, ich melde mich gleich, erst muss der Angriffstrupp da gewesen sein	Pausing
+UAV	Ja	Agreement
+TL	UGV 2 von Einsatzleiter	TurnAssign
+UGV-1	Fotos sind raus	Inform
+UGV-1	ja Andreas mitgehört drei gehfähige Personen	Auto-positive
+UGV-1	ja, weil ich stehe vor einer da liegt auch ein Trümmerteil davor	Inform
+UGV-2	ja, kommt sofort	AcceptRequest
+TL	Hinweis an alle die vermisste Person ist noch nicht gefunden kommen	Inform
+UAV	auf einem Wärmebild ist links liegend die Person auf einem zylindrigen Gegenstand	Answer
+UGV-2	befinde mich noch in der Startposition	Inform
+TL	melden wenn Einsatzbereitschaft gegeben	Request
+TL	Und desweiteren erkunden Sie die südliche Gebäudewand von ihrem Standort aus in westlicher Richtung	Request
+UAV	wir wären wieder startklar, wenn du was neues für uns hast?	Inform
+TL	ja verstanden die Drohne startet wieder	Auto-positive
+UAV	ich müsste erneut zurück wegen Akku Tausch	Inform
+TL	UAV 1, kommen	TurnAccept
+TL	Also ich seh euch beide ihr steht beide am Eingang des Ganges hintereinander	Inform
+UGV-2	UGV 2 hört	TurnAccept
+UGV-1	nein, negativ	Disconfirm
+UAV	Das ist südlich das ist es an der an der Position wo Echo-Start wo der Echo-Punkt ist also der der Halleneingang hier	Answer
+UGV-1	ja ich setze Personensuche fort	AcceptRequest
+UGV-1	Ich bestehe an einem Gang am Anfang der Halle Eingang Blickrichtung kann ich dir jetzt nicht sagen	Inform
+UGV-2	Teamleiter von UGV-2	TurnAssign
+TL	du hast mir jetzt ein weiteres Foto geschickt, ist das richtig?	CheckQuestion
+TL	das ist eigentlich nicht notwendig	DeclineOffer
+TL	das ist verstanden	Auto-positive
+TL	UGV 2 von Einsatzleiter	TurnAssign
+UGV-2	ja, ich hab hier technische Probleme, ich kann meine Flipper nicht bewegen und der Laser hat hinter sich	Inform
+UGV-2	ja, UGV 1 von UGV 2	TurnAssign
+TL	Robot 2 von Thorsten kommen	TurnAssign
+TL	Teamleader, verstanden	Auto-positive
+TL	hier Markus kommen	TurnAccept
+TL	Lena, sag nochmal die letzte Meldung, hab ich nicht mitgekriegt	Auto-negative
+TL	Frage zunächst, wer hat den Roboter mit dem Arm?	SetQuestion
+UGV-2	nein negativ	Disconfirm
+UAV	ich teile dir jetzt noch ein Bild, wo du zwei Punkte siehst, die Wärmesignaturen plus dich, deine Position und deinen Begleiter	Offer
+UGV-1	ja, ich stehe jetzt am Fuß der Rampe hab dir ein Bild geschickt kannst du mal was gucken, ob da was Interessantes ist	Inform
+UAV	Ja ich hab dir ein Bild geteilt mit einem recht guten Überblick über die Gebäudestruktur und die Halle vielleicht hilft es zu	Inform
+TL	Gruppe Drohne von Teamleader, kommen	TurnAssign
+UGV-1	Ja Teamleader von UGV-1 kommen	TurnAssign
+TL	Okay das scheint 297 zu sein	Answer
+TL	du hattest mir gerade das Bild geschickt, ja?	CheckQuestion
+UGV-1	ja Andreas mitgehört zwei Personen in der Nähe des Hochofens	Auto-positive
+UGV-1	habe im ersten OG gerade in der Brandentwicklung ein Gefahrgut-Fass grün mit der Kennzeichnung umweltgefährdender Stoff entdeckt	Inform
+TL	UGV 2 erreicht?	PropositionalQuestion
+TL	UGV-2 ich krieg deine Daten immer noch nicht	Disagreement
+TL	Lena für Benno, kommen	TurnAssign
+UAV	ich hab dir doch noch ein Bild geschickt in Infrarot	Inform
+UGV-1	eine Person am Boden liegend gefunden	Inform
+UGV-1	kommen	TurnAccept
+TL	an allen - an alle Einsatz- eingesetzten Kräfte, UGV 1, UGV 2 und UAV	TurnTake
+TL	UGV 1 damit warten	DeclineOffer
+TL	du sollst zur Rauchentwicklung fahren	Request
+TL	UGV-2 von Teamleiter	TurnAssign
+UAV	aber ich hab nochmal ein Bild hinterher geschickt, die Rauchentwicklung, die verringert sich zwischenzeitlich immer wieder es ist aber auch sehr schwierig, aufgrund des Windes, genaue Bilder zu erkennen, weil die Drohne noch sehr stark hin und her schwankt	Inform
+UGV-1	Ich würde jetzt einfach geradeaus fahren und schauen was ich so weiter finde Kommen	Offer
+UGV-1	weitere Foto von grünen Fass mit grüner Flasche drauf wurde dir entsandt	Inform
+TL	UGV 1 von Einsatzleiter	TurnAssign
+TL	Thorsten hört kommen	TurnAccept
+UGV-1	Ja mein TDS muss neu gestartet werden	Inform
+UGV-1	ja, ich hab 'n blaues Fass gefunden mit Aufschrift	Inform
+TL	folgenden Auftrag an Roboter 2 suchen Sie den Standort des Roboters 1	Request
+TL	ich schick dir den Angriffstrupp	Promise
+TL	ja, verstanden	Auto-positive
+UGV-2	Ja also ich hab gerade jetzt hier ein blaues Fass gefunden so ein übliches Chemikalienfass	Inform
+UGV-1	Teamleader von UGV 1	TurnTake
+UGV-1	Hier UGV-1	TurnAccept
+TL	Thorsten hört kommen	TurnAccept
+TL	Höre	TurnAccept
+TL	ja, verstanden	Auto-positive
+TL	Ursache ist unbekannt Rauchentwicklung, vermutlich auch Feuer, mehrere vermisste Personen, Anzahl der vermissten Personen ist ebenfalls unbekannt	Inform
+UGV-2	hab ich schon	AddressRequest
+TL	ja, höre	TurnAccept
+TL	Teamleader hört	TurnAccept
+TL	dass du dieses Bild nochmal machst, aber reinzoomst	Request
+TL	UGV 2 von Einsatzleiter	TurnAssign
+UGV-2	wir haben aktuell immer noch Probleme mit der Steuerung	Inform
+TL	Auftrag lautet aus der Luft versuchen den Roboter 1 zu finden und dann abzufotografieren	Request
+TL	hier Markus verstanden	Auto-positive
+UGV-1	nein negativ	Disconfirm
+UAV	ich hab dir gerade noch mal ein Bild geteilt, und zwar ist genau in dem Fadenkreuz sichtbar, das sind zwei Punkte, die Wärme abstrahlen, da müsstest du nochmal nachgucken	Inform
+TL	zwischen den Hochöfen, da steht irgendwo ein grünes Fass und da kommt die Rauchentwicklung her	Inform
+TL	die linke Treppe oder die rechte Treppe auf dein'm Foto?	ChoiceQuestion
+UGV-1	Ich seh ein extrem helles hell beleuchtetes Gerät	Inform
+TL	nochmal wiederholen Andreas	Auto-negative
+UAV	Markus für Dirk	TurnAssign
+UGV-1	ja, das ist negativ	DeclineOffer
+UAV	neuer Akku ist bereit	Inform
+TL	Kannst du ein Foto machen?	Request
+UGV-1	habe den westlichen Hallenteil bis zum Ende jetzt erkundet, keine weiteren Erkenntnisse	Inform
+TL	Haben Sie irgendwelche Anzeichen von Gebäudeschäden gefunden?	Question
+TL	ja verstanden	Auto-positive
+UGV-2	ja, wie ist da meine Blickrichtung auf dem Bild?	AcceptRequest
+UGV-1	der Teamleadaer von Operator 1, kommen	TurnAssign
+TL	Feuerwehr Bochum von Markus kommen	TurnAssign
+TL	Wenn ihr gleich vorgeht bitte meldet mir die üblichen Gefahren an der Einsatzstelle, Feuer, Opfer	Request
+TL	ja, UAV, wie sieht's aus, könnt ihr fliegen?	Question
+TL	verstanden	Auto-positive
+TL	Einsatzauftrag bitte aufsteigen Übersichtsfoto machen wenn möglich aus allen vier Himmelsrichtungen kommen	Request
+UGV-1	ich bin drauf, ich versuch das mal zu rollen	Offer
+TL	Teamleader	TurnAccept
+UGV-2	ja, Teamleader von UGV 2	TurnAssign
+TL	Sie kommt sehr leise über Funk	Inform
+UAV	links mittig ist die Person liegend	Inform
+UAV	ja wir schalten gerade um, ich komme gleich wieder mit neuen Infos	Promise
+UAV	gut	AcceptRequest
+TL	ich höre	TurnAccept
+UGV-1	ja, ich hab nochmal 'ne Nahaufnahme von dem Fass und 'ne Wärmesignatur von dem Fass geschickt	Inform
+TL	ich höre	TurnAccept
+UGV-1	Ja schau mal auf das Foto bin ich in der Nähe des UGV-2? Frage	Request
+TL	Kommen	TurnAccept
+UGV-1	negativ keine nennenswerten Erkenntnisse	Disconfirm
+UAV	die Situation von gerade kann ich jetzt nicht mehr gut einsehen weil die Rauchwolke genau davor ist	Inform
+UGV-2	Ja dann versuche ich mal vorsichtig zurückzukommen	AcceptRequest
+TL	Roboter 1 können Sie den Standort nochmal anfahren	Request
+TL	ich hör' dich	TurnAccept
+TL	UAV von Einsatzleiter	TurnAssign
+UGV-1	ich kann dir lediglich ein Wärmebild schicken	Offer
+TL	ja, fahr mal rein	AcceptOffer
+TL	verstanden	Auto-positive
+UGV-1	das ist richtig, und da bin ich gerade am Anfangen	Confirm
+UGV-1	ja, ist verstanden	AcceptRequest
+UGV-2	Ergeht irgendwie so eine Plattform mit so einer Metallbox auf Palette	Inform
+TL	ist verstanden, ich kann momentan aus technischen Gründen nur leider nichts sehen	Auto-positive
+UGV-1	Ja das ist okay ist verstanden	Auto-positive
+UGV-2	ja, ist soweit verstanden	AcceptRequest
+TL	habt ihr die Möglichkeit, die Ebene zu wechseln?	PropositionalQuestion
+UAV	ja, wir haben uns gerade die Bilder noch einmal angeguckt, da könnte nochmal was sein	Inform
+UGV-1	Teamleader von UGV-1 kommen	TurnTake
+UGV-1	Viel zu weit entfernt	Inform
+TL	O. k.	Auto-positive
+UGV-2	Da steht ein Stuhl auf dem Stuhl liegt ein Paket und vor dem Stuhl steht ein Paket	Inform
+TL	Guck dir das mal genauer an bitte wenn du da hochkommst	Request
+UGV-2	Südliche Gebäudewand in westlicher Richtung kontrollieren	AcceptRequest
+TL	Ich orientiere mich nur an der Karte das heißt nach rechts wäre Osten du folgst einfach der langen Straße praktisch	Instruct
+TL	Und guck mal ob du ein genaues Bild von diesen Samples kriegen kannst	Request
+UGV-2	wir haben massive Probleme mit der Steuerung	AddressRequest
+TL	Teamleader hört	TurnAccept
+TL	alles klar	Auto-positive
+TL	ja, kommen Sie	TurnAssign
+TL	das ist verstanden	Auto-positive
+TL	Operator 1 für Benno	TurnAssign
+TL	Dirk von Thorsten kommen	TurnAssign
+TL	Dein Standort ist Position ECO richtig?	CheckQuestion
+UGV-1	ich bin jetzt an dem Treppenabsatz sehe eine Person in orangefarbener Warnweste	Inform
+UAV	die UAV hört	TurnAccept
+TL	Teamleader hört Roboter 1	TurnAccept
+UGV-2	das ist korrekt	Confirm
+Speaker	Dialogue Turn Text	Communicative Function
+TL	ja, verstanden	AcceptSuggestion
+UGV-1	steht aufrecht und ist keinerlei Flüssigkeitsaustritt zu erkennen	Inform
+TL	wer hat dieses Foto gemacht kommen	SetQuestion
+TL	UAV von Einsatzleiter, kommen	TurnAssign
+TL	stelle fest ein dichtes 200-Liter-Fass umweltgefährdend gekennzeichnet	Auto-positive
+UGV-1	zur Zeit hier bei den Fässern kann ich nicht hoch	Disconfirm
+TL	ja, das ist verstanden	Auto-positive
+TL	Gib mir Bescheid wenn du weiterfährst	Request
+TL	Hinweis an alle eingeteilten Kräfte Übungsende	Inform
+TL	kann man von oben vielleicht mir ein Foto schicken?	Request
+TL	ja, verstanden	Auto-positive
+TL	folgenden Auftrag: den gleichen Weg nehmen wie Operator 1	Request
+TL	Okay	Auto-positive
+UGV-1	das ist richtig ich habe eine Person gefunden	Confirm
+UAV	Benno für Lena	TurnAssign
+TL	dann müsst ihr euch von da aus in östlicher Richtung bewegen	Request
+UAV	die Drohne startet wieder	Inform
+UAV	ja, du hattest gerade noch mal einen Auftrag, kann du den mir wiederholen?	Request
+UGV-1	Markus von Andreas kommen	TurnAssign
+UGV-1	Einsatzleiter von UGV 1	TurnAssign
+TL	Ja ist verstanden	Auto-positive
+UAV	Erbitte weitere Anweisungen	Request
+TL	Höre	TurnAccept
+UGV-2	wir stehen in der Nähe des grünen Fasses, also ist das grüne Fass kann ich durch die Kamera sehen, aber ich kann ihn nicht verfahren, das Radar scheint irgendwie nicht ge- richtig zu funktionieren	Inform
+UGV-2	UGV-1 kriegt da noch eine Einweisung	Inform
+UAV	die UAV hört	TurnAccept
+TL	Teamleiter, verstanden	Auto-positive
+UGV-1	UGV 1 Teamleader von UGV 1	TurnAssign
+UGV-2	also, aktuell stehe ich noch an dem flachen Bereich der Rampe	Answer
+UGV-1	ja, Frage: soll ich nach weiteren Personen suchen?	Offer
+TL	wenn ich das richtig sehe, kommt der Rauch am rechten Behälter Blickrichtung Süd raus	Inform
+TL	Dirk von Markus kommen	TurnAssign
+UGV-1	ja richtig	Allo-positive
+UAV	das habe ich verstanden	AcceptRequest
+UAV	hast du eine Ebene? auf welcher Ebene?	Question
+TL	wir haben keine am Boden liegend befindliche Person ist das korrekt?	Auto-positive
+TL	ja, ist verstanden	Auto-positive
+TL	alle bitte hier zum Treffpunkt ans Zelt kommen	Request
+TL	Kreise mal bitte jetzt dann um ASA 352 herum	Request
+UGV-1	ich mach ein Foto und schick's dir	Offer
+UGV-1	Teamleader vom Operator 1	TurnAssign
+UAV	Teamleader von der UAV, kommen	TurnAssign
+UGV-1	ich habe dir einmal ein Thermo-Image der Person geschickt und einmal ein Live-Bild der Person	Inform
+UAV	ja, wir haben einmal den Akku gewechselt, bis jetzt noch kein Rauch festzustellen, aber wir haben eine Person gefunden	TurnAccept
+UGV-2	ja, hier steht wieder alles	Inform
+TL	Bitte melden wenn wieder einsatzbereit	Request
+UGV-2	ja, ist schon etwas länger her	Confirm
+Speaker	Dialogue Turn Text	Communicative Function
+UGV-1	Markus von Andreas kommen	TurnAssign
+UAV	also es passt gut dass das drei gehfähige Personen an einer liegenden sind	Agreement
+UGV-2	Ja das ist verstanden	Auto-positive
+TL	mach mal Fotos auch, wenn du was findest, dass man den Weg nachvollziehen kann	Request
+TL	Dein Einsatzauftrag trotzdem setz den Arm ein und nimm die Probe auf	Request
+TL	UGV-1	TurnAssign
+TL	das gleiche Bild, was du jetzt gemacht hast, da in die Mitte reinzoomen, da wo die Rauchentwicklung ist	Answer
+UAV	wir werden gleich mit der Personensuche starten	Inform
+TL	UGV-2	TurnAssign
+UGV-1	ja, ist verstanden	Auto-positive
+UGV-1	Markus von Andreas kommen	TurnAssign
+UGV-1	ja Andreas kommen	TurnAccept
+TL	Operator 2 für Benno, kommen	TurnAssign
+TL	ich höre	TurnAccept
+UGV-1	ja, ist verstanden	Auto-positive
+UGV-1	weiterhin, das Fass nicht beschädigt	Inform
+TL	Ich seh euch gleich am Eingang der Halle	Inform
+TL	Höre	TurnAccept
+UAV	Teamleiter 1 für UAV Operator	TurnAssign
+TL	ja, verstanden	AcceptOffer
+UGV-1	Teamleader von UGV 1	TurnTake
+TL	wo ist denn deine Position jetzt?	SetQuestion
+UGV-1	Treppenaufgang und dann direkt links blauer Kanister unbekannter Inhalt sieht auch ebenfalls dicht aus	Inform
+UAV	unterhalb des Tankes ist Fleck, der auffällig ist, und recht oben am Tank guckst du mal?	Inform
+TL	Treppenabsatz ersten OG nach 10 bis 20 metern linker Seite erste Person korrekt?	CheckQuestion
+TL	verstanden Standort Treppenabsatz	Auto-positive
+UGV-2	alle paar Sekunden setzt mir der Roboter aus	Inform
+TL	UGV 2 von Einsatzleiter	TurnAssign
+UAV	Lena hört	TurnAccept
+TL	UAV von Einsatzleiter	TurnAssign
+TL	ich höre	TurnAccept
+TL	Dirk kommen	TurnAccept
+UGV-2	UGV 2 hört	TurnAccept
+UGV-1	ich habe hier extreme Rauchentwicklung	Inform
+TL	Ja war schon weiter	AcceptOffer
+UGV-1	ja, das verstanden	Auto-positive
+UGV-1	Ja ich werd jetzt rechts abbiegen	Inform
+UGV-1	jetzt die Frage, ob ich mich weiter fortbewegen soll	Question
+TL	UGV 1 aber warten	Request
+UGV-1	Eher Status 6 kommen	Answer
+TL	ja, ist verstanden	Auto-positive
+TL	ja, verstanden	Auto-positive
+UGV-1	Ja kommt	AcceptRequest
+TL	ja, startet mal und fliegt ja, startet erst mal	Answer
+UGV-2	ja, ich hab jetzt nochmal zwei Bilder gemacht, einmal von der Rauchentwicklung und einmal von dem grünen Fass, was hier liegt	Inform
+TL	absuchen der Fläche vielleicht finden wir die Person dort mit dem Wärmebild	Request
+TL	UGV 2 von Einsatzleiter	TurnAssign
+TL	mach mal ein Foto zur Orientierung für mich	Request
+TL	ja	Auto-positive
+TL	Ja das ist verstanden	Auto-positive
+TL	UGV-1	TurnTake
+TL	ja, verstanden	Auto-positive
+TL	letzten Teil des Satzes habe ich nicht verstanden	Auto-negative
+TL	Ja das ist verstanden	Auto-positive
+UAV	die Drohne ist wieder in der Luft	Inform
+UGV-1	kannst du mir nochmal ein bisschen näher beschreiben, wo die Rauchentwicklung ist?	Request
+UAV	Einsatzleiter von UAV	TurnAssign
+TL	hör dich	TurnAccept
+TL	ja, ich melde mich gleich bei euch	Pausing
+UGV-1	weitererkunden in westlicher Richtung, verstanden	Auto-positive
+UGV-2	ja, ich versuche eigentlich, ins zweite Obergeschoss zu kommen, aber ich hab hier erhebliche Probleme mit der Technik mein Roboter ist Made in Taiwan	Inform
+TL	ja, verstanden	Auto-positive
+TL	UGV-1	TurnAccept
+UAV	Markus für Dirk	TurnAssign
+UAV	Vor zur Information und Protektion oberhalb	Inform
+TL	ja, richtig	AcceptOffer
+TL	du hast den Roboter mit der Infrarot-Kamera, ist das richtig?	CheckQuestion
+UGV-1	ich höre dich	TurnAccept
+UGV-1	ja, ich fahr zur Rauchentwicklung	AcceptRequest
+UGV-1	ja, ist negativ	Disconfirm
+TL	wir haben drei gehfähige und eine am Boden liegende Person	Inform
+UGV-1	ja richtig	Allo-positive
+TL	hast du Erkenntnis über zwei gehfähige Personen anhand dieses Bildes was ich auch erhalten habe?	PropositionalQuestion
+UGV-1	ich beweg' mich weiter fort	Offer
+UAV	Thorsten für Dirk kommen	TurnAssign
+UGV-2	Hier UGV-2	TurnAccept
+UGV-1	I lost the connection to the TDF	Inform
+UGV-1	sobald ich eine Veränderung habe schicke ich dir ein Bild	AddressRequest
+TL	UGV 2, hört	TurnAccept
+TL	Höre	TurnAccept
+TL	sollen also zwei bis drei Vermisste sein nach den ersten Aussagen	Inform
+TL	Ja das ist verstanden	Auto-positive
+TL	schau auch mal wie weit die Rauchentwicklung da ausgedehnt ist	Request
+TL	Einsatzauftrag du fährst den langen Gang entlang ich gehe mal davon aus dass es am südlichen Wand der Halle ist und bleibst bitte auf der Ebene	Instruct
+TL	Operator 1 für Teamleader, kommen	TurnAssign
+UGV-1	ich kann das Fass noch einmal umkreisen und gucken ob es eine Beschriftung drauf ist	Offer
+UAV	UAV hört	TurnAccept
+UGV-2	Ja das ist so verstanden Ich fahr weiter Richtung Norden in die Halle rein und suche mir einen Zugang in Richtung Osten	Auto-positive
+UAV	Weiter kann ich die Aufschrift des Chemikalienfasses nicht identifizieren da die verletzte Person im Weg sitzt	Inform
+UGV-2	UGV 2 hört	TurnAccept
+UAV	Thorsten für Dirk	TurnAssign
+TL	Gibt's ein technisches Problem bei dir?	PropositionalQuestion
+UGV-1	wir hätten die Möglichkeit, von hier aus in den Komplex reinzufahren und dort innen zu erkunden	Offer
+TL	kannst du einmal ein Foto von dem Fass machen in Richtung der Treppe, dass man einen Orientierungspunkt hat?	Request
+TL	Gib mir bitte nochmal ein Foto von deiner Fahrtrichtung	Request
+UAV	Lena hört	TurnAccept
+UAV	der Akku ist jetzt leer, wir müssen jetzt auch landen, und warten am Boden auf weitere Anweisungen	Inform
+TL	das ist verstanden	Auto-positive
+UGV-1	korrekt das Fass selber ist grün	Agreement
+TL	UGV 1, höre	TurnAccept
+UGV-1	ja, ich hab gerade ein Foto geschossen, hier sind zwei Treppen auf der linken Seite, allerdings kein Angriffstrupp	Inform
+TL	Okay	Auto-positive
+TL	UGV 2 von Einsatzleiter	TurnAssign
+UGV-1	der Teamleader von Operator 1, kommen	TurnAssign
+UGV-1	Teamleader von UGV 1	TurnAssign
+TL	Ja dann versuch vorsichtig zurückzukommen	Request
+TL	neuer Auftrag lautet Suchen von Leckagen von Undichtigkeiten und Chemikalien	Request
+TL	zur Lage die Personen sind alle gerettet und der medizinischen Versorgung zugeführt	Inform
+TL	Das ist verstanden	Auto-positive
+TL	wie verhalten sich die vier Personen verlassen sie das Gebäude und wenn ja in welche Richtung?	Question
+TL	ja, versuch das mal	AcceptOffer
+UGV-2	ich hab auch nochmal ein Bild geschickt	Inform
+TL	ich höre	TurnAccept
+TL	Wenn's geht fährst du nicht den Weg zurück den du gekommen bist sondern eben erst mal Richtung Süden von Darmstadt aus und dann wieder Richtung Richtung Startpunkt sozusagen	Instruct
+UGV-1	von außen keine Gefahrensymbole von der Vorderseite, ich werde jetzt noch die rechte Seite erkunden	Inform
+UAV	Alles klar danke	AcceptRequest
+UGV-1	UGV 1 hört	TurnAccept
+UGV-1	okay	AcceptRequest
+TL	Sehen Sie den Victim der durch die Drohne eingegeben wurde?	Question
+TL	UGV 2 von Einsatzleiter	TurnAssign
+UGV-2	und dann war die andere Treppe, war mit so 'nem weißen Geländer abgesperrt, hier	Inform
+TL	ja, schickst du mir nochmal ein Bild?	Request
+UGV-1	Teamleader von UGV 1	TurnAssign
+TL	Macht bitte Fotos von Positionen die euch blöd vorkommen oder interessant vorkommen	Request
+TL	fahrt ihr runter oder fahrt ihr auch über diese Rampe?	ChoiceQuestion
+UAV	müsste zu erkennen sein	Confirm
+TL	Ja verstanden	Auto-positive
+UAV	Benno für UAV Operator	TurnAssign
+TL	kommst du näher an das blaue Fass, dass wir eine Erkennung haben?	PropositionalQuestion
+UAV	Dirk hört	TurnAccept
+TL	warten	Pausing
+UGV-1	im ersten Obergeschoss wo ich mich gerade aufhalte müsste auch der Brandherd sein	Inform
+UGV-1	zur Info, das ist der Blick in östlicher Richtung	Inform
+TL	UGV 2 von Einsatzleiter, kommen	TurnAssign
+TL	ja, verstanden	Auto-positive
+UGV-1	ich sehe ein Fass was einfach nur umgekippt ist, keine Leckage	Answer
+TL	ja, ich höre	TurnAccept
+UAV	Teamleiter von UAV	TurnAssign
+UAV	hier ist die UAV	TurnAccept
+UGV-2	ja, UGV 2	Confirm
+TL	ja hab ich mir fast gedacht	Auto-positive
+UGV-2	Ich hab dir gerade ein Bild geschickt	Inform
+TL	was machen die technischen Probleme, wieder einsatzbereit?	CheckQuestion
+UGV-1	ja, Frage: soll ich weiter erkunden? das Fass liegen lassen, weiterfahren?	PropositionalQuestion
+TL	ja such mal noch weiter	AcceptOffer
+UAV	ja, das habe ich auch verstanden	AcceptRequest
+UGV-1	scheint keine Flüssigkeit auszutreten, und Gefahrenzettel oder Si- andere Signaturen sind auch nicht zu sehen	Inform
+TL	verstanden	Auto-positive
+UGV-1	Das ist mir bekannt	Agreement
+UAV	ja verstanden	AcceptRequest
+TL	rechte Treppe hoch, rechts in den Raum rein, korrekt?	CheckQuestion
+UGV-1	Markus von Andreas kommen	TurnAssign
+UAV	dann sind wir wieder dabei und suchen dann nach weiteren Fässern	Promise
+UAV	Dirk hört	TurnAccept
+UAV	Benno für Lena, wir sind jetzt wieder startklar	TurnAssign
+TL	das Fass, das steht dort irgendwo, das war nur zur Orientierung, aber mach mir mal ein Foto von dem Fass	Inform
+UAV	hier ist die UAV	TurnAccept
+TL	UAV von Einsatzleiter	TurnAssign
+TL	hier Markus an alle Roboter	TurnTake
+UGV-1	Teamleader von UGV-1 kommen	TurnAssign
+TL	Bis jetzt ist das Foto noch nicht angekommen haben Sie auf Teilen geklickt?	Inform
+UAV	Dirk hört	TurnAccept
+TL	verstanden	Auto-positive
+UGV-1	ja, jetzt nicht	TurnAccept
+TL	UAV für Einsatzleitung	TurnAssign
+TL	ja verstanden	Auto-positive
+TL	ja, verstanden	Auto-positive
+UGV-1	ich schike dir gleich Fotos	Promise
+UGV-1	meine Einschätzung unter PA jederzeit möglich ja	Confirm
+UAV	möglicherweise an dem Objekt sind noch mehrere Wärmequellen, ich kann's zur Zeit nicht genau sagen	Inform
+TL	Thorsten hört Andreas kommt	TurnAccept
+TL	zu allen Roboter mal kurz Stop	Request
+TL	unsere Aufgabe ist es halt Menschenrettung	Inform
+TL	höre	TurnAccept
+TL	Das ist verstanden dann folgen Sie den UGV-2	Auto-positive
+UGV-2	dafür müsstest du mal sagen, wo wir ungefähr sind, weil das können wir selber klar nicht feststellen	AddressRequest
+TL	dieses grüne Fass - da ist der Rauch, korrekt?	CheckQuestion
+UGV-2	Und alle 15 Minuten Gasdetektoren einschalten verstanden	AcceptRequest
+TL	gibt es noch mehr Raum, der noch nicht abgesucht ist?	PropositionalQuestion
+UGV-1	Einsatzleiter von UGV 1	TurnAssign
+TL	UGV 2 von Einsatzleiter	TurnAssign
+TL	hier Markus verstanden	Auto-positive
+TL	ja	Auto-positive
+TL	UGV 1, hast du schon ein Bild gemacht?	PropositionalQuestion
+TL	ja, können weiter fahren	Answer
+UAV	wir haben ein neues Live-Bild, neue Rauchentwicklung in dem hinteren Bereich	Inform
+UGV-1	Ja ich prüf das ob ich da weiterkomme kommen	AcceptRequest
+TL	Augenblick	Pausing
+UGV-2	Teamleiter von UGV-2	TurnAssign
+TL	Ja hier ist mal nichts dann liegt's an mir	Disagreement
+UGV-1	wir haben hier einen Gefahrenzettel auf dem Behälter	Inform
+TL	ja, verstanden	Auto-positive
+UGV-1	ja Andreas kommen	TurnAccept
+TL	bräuchte nur noch ein klareres Foto von der Person	Request
+UGV-1	werde jetzt ein Foto davon machen und dir schicken	Offer
+UGV-2	ich habe dir ein Foto geschickt von dem grünen Fass und wo ich mich jetzt gerade befinde	Inform
+TL	Lena für Benno	TurnAssign
+UGV-1	okay	Auto-positive
+TL	Ja was willst du mir damit sagen?	Question
+UGV-1	ja, wir können die Orientierung nehmen von dem ersten Fass von dem ersten Fass geht's ja die Treppe hoch, und da stand direkt das erste Fass und davon gesehen dann rechts	Inform
+TL	Teamleader hört	TurnAccept
+UGV-1	die rechte Treppe, wo die Rauchentwicklung zu sehen war	Answer
+UAV	Und jetzt sind wir gelandet um den Akku zu tauschen	Inform
+TL	Bitte mach mir mal ein Foto von deinem Standort kommen	Request
+UGV-1	ja, die Punkte sind hier minimal, ich würde sagen zirka fünf bis zehn zentimeter im Durchmesser	Answer
+UGV-1	Teamleader von UGV-1	TurnAssign
+TL	UAV 1 habt ihr das Ziel erreicht?	PropositionalQuestion
+UGV-1	ist gerade die erste Treppe nach oben gefahren zur Rauchentwicklung, ich erkunde dort im ersten Raum	Answer
+UAV	ich hör' dich	TurnAccept
+TL	verstanden	Auto-positive
+UAV	die Drohne wird startbereit gemacht	Inform
+TL	das ist verstanden	Auto-positive
+TL	Andreas kommen	TurnAccept
+UGV-2	ja, und das Fass, hast du gesagt, da soll ich dran vorbei fahren, ne?	Auto-positive
+TL	ja, ihr hattet doch eben zwei Fässer ausgemacht, von oben, könnt ihr den UGV 2 dorthin lotsen?	Request
+UAV	Einsatzleiter von UAV	TurnAssign
+UGV-2	ne, ich bin vor diesem Hochofen der mehrere Bullaugen hat	Disconfirm
+TL	die Roboter sollen alle zurückfahren und dann treffen wir uns hier	Instruct
+TL	ja, habe verstanden	Auto-positive
+TL	wiederhole am Treppenausgang blauer Kanister	Auto-positive
+UAV	ich hab dir ein Bild geschickt von der Drohne aus der Luft mit Blickrichtung Westen	Inform
+UGV-2	ja, Foto ist geteilt	Inform
+TL	okay	Auto-positive
+TL	Der UGV-2 geht zur südlichen Gebäudewand das ist Ihnen bekannt	Inform
+UAV	Drohne landet wegen leerem Akku	Inform
+UAV	wir sind mit der Drohne jetzt in der Luft und werden hinter das Gebäude fliegen	Offer
+TL	ich höre	TurnAccept
+UGV-2	negativ	Answer
+TL	das ist gut	AcceptOffer
+UGV-1	schicke dir nochmal ein Bild	Offer
+UGV-1	ja ich fahre den Rettungskräften über meinen Angriffsweg entgegen und versuche sie zu lotsen	AcceptRequest
+UGV-2	ja, Operator 2 hat verstanden	Auto-positive
+UGV-1	ja, Frage: kommen meine Fotos an?	PropositionalQuestion
+UGV-1	Einsatzleiter von UGV 1	TurnAssign
+UGV-1	Frage sind diese Personen alle bei der liegenden Person?	PropositionalQuestion
+TL	die Rauchentwicklung, die das UAV gemeldet hat, könnt ihr da näher erkunden, inwiefern wir da noch mit Kräften vorgehen können?	Request
+UGV-2	UGV 2 hört	TurnAccept
+UGV-1	ich wäre soweit einsatzbereit	Inform
+UAV	es handelt sich um drei Personen die nebeneinander stehen	Answer
+UGV-1	Teamleader von UGV 1	TurnAccept
+TL	Dann Foto machen	Request
+TL	Dirk kommen	TurnAccept
+UAV	das ist korrekt	Allo-positive
+TL	hier Markus kommen	TurnAccept
+TL	hast du von der Fo- Person ein Foto gemacht und mir geschickt?	PropositionalQuestion
+UAV	verstanden	Auto-positive
+UGV-1	um diesen beiden Fässern und dem Kanister ist kein Anschein von irgend einer Leckageaber erneut nochmal versuchen muss	Answer
+TL	sieht man irgendwo eine Leckage in der Nähe des Fasses?	PropositionalQuestion
+UGV-1	ja, verstanden	Auto-positive
+UGV-1	Teamleader von UGV-1	TurnAssign
+UAV	UAV hört	TurnAccept
+UGV-1	wenn du das Foto von dem Fass siehst, siehst du im hinteren Bereich, hinter dem Fass die Bullaugen des Hochofens	Inform
+UGV-1	ich bin jetzt einen Weg bis zum Ende weitergefahren und dann gehe ich linker Handregel weiter	Inform
+TL	UGV 2 von Teamleader	TurnAssign
+UGV-1	ja, hier ist der UGV 1 von Teamleader	TurnAssign
+UAV	UAV hört	TurnAccept
+UGV-1	ja, das ist verstanden	AcceptRequest
+UGV-1	Hier ist UGV-1	TurnAccept
+UAV	Benno für Lena	TurnAssign
+TL	ich höre	TurnAccept
+TL	Teamleader	TurnAccept
+UAV	Muss ich kurz identifizieren wo ich bin ich versuche mich mal zu orientieren	Inform
+TL	Ja okay verstanden	Auto-positive
+UAV	Lena hört	TurnAccept
+UGV-1	UGV 1 hört	TurnAccept
+TL	ich höre	TurnAccept
+TL	verstanden	Auto-positive
+TL	ja das ist verstanden	Auto-positive
+TL	Operator 1, schickst du mir die Bilder auch einmal rüber, die du gemacht hast?	Request
+UAV	Thorsten für Dirk kommen	TurnAssign
+TL	UGV 1 von Einsatzleiter, kommen	TurnAssign
+UGV-1	Einsatzleiter von UGV 1	TurnAssign
+TL	kannst du dich denn noch bewegen?	PropositionalQuestion
+UGV-1	ich habe dir ebenfalls Bilder von drei Personen die aufeinander stehen rübergeschickt	Inform
+UAV	ja, ich versuch, dir nochmal ein besseres Bild zu liefern	Promise
+TL	ich höre	TurnAccept
+TL	Sollten dabei Verletzte oder chemische Substanzen gesichtet werden ebenfalls bitte melden und auf der Karte markieren	Instruct
+TL	ja danke	AcceptSuggestion
+UGV-1	ja, es handelt sich um einen blauen Kanister, der aufrecht steht, verschlossen ist mit dem Inhalt Otalin ich hab ein Foto gemacht und schick's dir	Inform
+UGV-1	ja habe die Rettungstrupps zum Standort der vermissten Person gebracht	Inform
+UGV-1	ich hab dir ein'n Schnappschuss erstellt, kannst du mal gucken, ob dir das recht ist, auf dieser Ebene zu suchen? das wäre jetzt der Blick in den westlichen Teil der Halle	Inform
+TL	dann bitte mal eins gerade vorweg	Request
+TL	UGV 1 von Einsatzleiter	TurnAssign
+UGV-1	ja, ich hab die brennenden Punkte gefunden	TurnAccept
+UAV	ne, leider immer noch nicht, es regnet zu sehr	Disconfirm
+UAV	Einsatzleiter von UAV-Drohne	TurnAssign
+TL	wie weit ist das von dem Treppenabsatz denn entfernt?	SetQuestion
+UGV-1	eine Person liegend am Boden gefunden erstes OG bei der Brandentwicklung	Inform
+UAV	Wir haben weitere Fotos von der Rauchentwickung direkt an der Startposition am Eingang	Inform
+TL	Sven, kommen	TurnAssign
+UGV-1	Weiter keine Feststellung rechts ist der Feuerlöscher	Inform
+UGV-1	ganz genau	Confirm
+UAV	der eine Ort, das sind zwei kleine Stellen, das ist unter dem Fass, was ich gerade schon mal geschickt habe, und rechts davon siehst du auch da im Bild sehr deutlich, 'ne Wärmesignatur, die etwas größer ist	Inform
+TL	ja, verstanden	Auto-positive
+TL	hier Markus an alle Operator	TurnTake
+UAV	UAV Operator, verstanden	Auto-positive
+UAV	Thorsten für Dirk kommen	TurnAssign
+UGV-1	Ja ich denke so 5-6 meter weiter bin ich noch nicht gekommen kommen	Answer
+UAV	UGV 1 von UAV	TurnAssign
+TL	in östlicher Richtung sollte das Gelände soweit abgesucht sein, denke ich?	CheckQuestion
+TL	warten	Pausing
+UGV-2	auf dem Weg zu der Tonne mit der Flasche obendrauf, da befinde ich mich gerade	Inform
+TL	hört	TurnAccept
+UGV-2	Du müsstest ein Bild gekriegt haben ASA 352 müsste rechts von mir von meiner Position auf dem Bild sein	Inform
+TL	Ja ich gucke	AcceptSuggestion
+TL	ja ich komme sofort wieder	Confirm
+UGV-1	ich komm'	TurnAccept
+UGV-2	Andreas von Daniel	TurnAssign
+UAV	Lena hört	TurnAccept
+TL	fliegt ihr in westlicher Richtung über dem eigentlichen Gelände und schickt mir dann mal ein Bild?	Request
+TL	Andreas Andreas von Markus kommen	TurnAssign
+UGV-2	Die erste Probenahme ist beendet das zweite Paket hängt in der Place pose über der Box	Answer
+UAV	Der UAV Pilot berichtet von Rauch der aus der Halle kommt	Inform
+TL	Thorsten hört Dirk kommt	TurnAccept
+TL	kann man da irgendwo was sehen? sehen wo es ein drittes Fass im Umlauf liegen könnte	Question
+UAV	ich hab dir ein Bild von der Wärmebild-Kamera geschickt	Inform
+TL	UGV-1 von Teamleiter	TurnAssign
+UGV-1	UGV-1	TurnAccept
+TL	fahr zu dem grünen Fass und erkunde um dieses grüne Fass herum, warum es da raucht	Request
+TL	UAV von Einsatzleiter, kommen	TurnAssign
+UGV-2	Roboter 2 hört	TurnAccept
+UGV-2	ja, ich bin jetzt wieder im Außenbereich	Answer
+TL	dann bewegt ihr euch einmal in östlicher Richtung?	Request
+TL	UGV-2 für Einsatzleiter	TurnAssign
+UGV-1	nähere mich der Rauchquelle	Inform
+UGV-1	UAV von UGV 1, kommen	TurnAssign
+UGV-2	UGV 2 hört	TurnAccept
+UGV-1	Habe aber hier extrem schlechte Sicht aufgrund von reflektierendem Licht kommen	Inform
+UGV-1	kommen Sie	TurnAccept
+TL	gut	Auto-positive
+UGV-2	ja, ich UGV 2	TurnAccept
+TL	Frage gerade: aktueller Standort?	Question
+UGV-2	UGV-2 hört	TurnAccept
+TL	UGV-1 für Einsatzleiter	TurnTake
+TL	Ja verstanden	Auto-positive
+UAV	ja, das habe ich verstanden	AcceptRequest
+UAV	Benno für Lena	TurnAssign
+UGV-1	Teamleader von Roboter 1 kommen	TurnAssign
+UGV-1	keine Gefahr	Inform
+TL	ja, verstanden	AcceptOffer
+TL	Fahr trotzdem erst mal in die Richtung	AcceptOffer
+TL	Ja verstanden	Auto-positive
+TL	ja, dann möchte ich dort eine Meldung haben, dann kümmere ich mich darum	Request
+TL	Operator 1 für Teamleiter, kommen	TurnAssign
+TL	Das heißt du kannst im Moment gar nichts machen?	CheckQuestion
+TL	UGV 1 von Einsatzleiter	TurnAssign
+UGV-1	nein	Disconfirm
+TL	UGV 2 von Einsatzleiter	TurnAssign
+UGV-2	ja, warten	Pausing
+TL	ja, verstanden	Auto-positive
+UGV-1	ja, Angriffstrupp war nicht vor Ort	Disagreement
+TL	beide Fässer sind noch nicht beschädigt	Auto-positive
+TL	Teamleader hört	TurnAccept
+UAV	die Rauchentwicklung kommt neben dem Hochofen zustande	Inform
+TL	dann bitte weiter suchen	Request
+UGV-1	ja, ich schicke	AcceptRequest
+UGV-1	ja, es gibt Treppen	Confirm
+UGV-1	Foto ist versandt	Inform
+UGV-1	Teamleader von Operator 1	TurnAssign
+UGV-1	ja, ich hab jetzt das Fass einmal umkreist kann auf dem Fass zwei Gefahrensymbole identifizieren, einmal rot mit Flamme, brennbar und einmal umweltgefährdend	Inform
+TL	Ja ebenfalls auf Chemikalien achten Trader Fluorid und Trader Oxin müssten auch irgendwo sein	Instruct
+TL	Ich sehe dass die Fotos geadded wurden ich seh sie noch nicht auf der Karte	Inform
+TL	Operator 2 für Teamleader, kommen	TurnAssign
+TL	Unsere Aufgabe erstellen einer Karte des Gebäudes	Inform
+UGV-1	Einsatzleiter von UGV 1, kommen	TurnAssign
+TL	ja, verstanden	Auto-positive
+TL	ja, fahren Sie wieder zurück ins Untergeschoss	Request
+UGV-1	hab dir ein Foto geschickt und werde mich dem jetzt nähern	Inform
+UAV	ja, wir suchen nach Brandnestern mittels Wärmebild-Kamera oder Infrarot-Kamera	AcceptRequest
+TL	ich höre	TurnAccept
+UGV-1	Teamleader von UGV-1 kommen	TurnAssign
+TL	UGV 2 von Teamleader, kommen	TurnAssign
+UGV-1	der Teamleader von Operator 1, kommen	TurnAssign
+UGV-1	Einsatzleiter von UGV 1, kommen	TurnAssign
+UAV	ja, wir brauchen noch einen Augenblick, tauschen eben die Kameras	Inform
+UGV-2	ja, verstanden	Auto-positive
+TL	seht ihr die drei Hochbehälter?	PropositionalQuestion
+UGV-1	Roboter 1 hat verstanden Übungsende	Auto-positive
+TL	Verstanden	Auto-positive
+UAV	ja	Interaction Structuring
+TL	Frage: könnt ihr aus eurer Position den UGV 1 sehen?	PropositionalQuestion
+UGV-2	UGV 2 hört	TurnAccept
+UAV	also - die Person müsste hinter dem großen Hochofen auf dem freien Weg sein	Inform
+TL	sind wir da gleich dass wir jetzt zwei Personen gefunden haben oder Bilder von zwei unterschiedlichen Personen haben?	PropositionalQuestion
+UGV-1	Bild kommt	Promise
+UAV	genau in der Mitte davon, also bei den grünen, da kommt der Qualm her	Inform
+UGV-1	ja, hier Operator 1	TurnAccept
+TL	Auf eurem TDS müsste mittig der Halle eine Person eingetragen worden sein	Inform
+TL	UGV-1 von Teamleiter	TurnAssign
+UGV-1	ich schicke dir auch gleich nochmal ein Bild mit der Thermal-Kamera	Offer
+TL	kann man die Temperatur von dem Fass messen?	PropositionalQuestion
+UGV-1	da siehst du im hinteren Bereich des des Fasses auch die Öffnung die Bullaugen des Hochofens, also können wir uns daran orientieren	Inform
+TL	ja, verstanden	Auto-positive
+UGV-1	Frage die drei gehfähigen Personen wurden aus der Luft erkannt ist das richtig?	CheckQuestion
+UGV-1	ich höre	TurnAccept
+UGV-2	UGV-2	TurnAccept
+UGV-1	Andreas verstanden	Auto-positive
+UAV	Thorsten für Dirk kommen	TurnAssign
+TL	gibt es irgendwelche Erkenntnisse zur Personensuche?	Question
+UGV-2	Ich versuch das mal	AcceptRequest
+UGV-2	UGV 2 hört	TurnAccept
+UGV-2	Teamleader von Operator 2, kommen	TurnAssign
+UGV-1	ja, verstanden	Auto-positive
+UGV-1	ja verstanden zwei bis drei Vermisste	Auto-positive
+TL	Operator 1 für Benno, kommen	TurnAssign
+UGV-1	ich habe jetzt hinter dem ersten Hochofen in östlicher Richtung einen weiteren Behälter gefunden	Inform
+TL	ja ich werte gerade die Bilder aus kommen	Promise
+TL	ja, verstanden	AcceptOffer
+UGV-1	Hier ist UGV-1	TurnAccept
+TL	den Suchbeginn bitte mitteilen	Request
+UAV	UAV hört	TurnAccept
+UGV-2	ja, mache ich	AcceptRequest
+UAV	Teamleader von UAV, kommen	TurnAssign
+TL	Frage: hast du ein Foto von dem grünen Fass gemacht?	PropositionalQuestion
+UGV-2	Einsatzleiter von UGV 2, kommen	TurnAssign
+TL	Wie ist jetzt dein Status	Question
+TL	Teamleader	TurnAccept
+UAV	ja die ist immer noch in der Luft	Confirm
+UAV	das zweite war eine Wärmesignatur, die ist genau in ähnlicher Position, wo sich das UAV gerade befindet - das U- das erdgebundene Fahrzeug	Inform
+TL	Höre	TurnAccept
+TL	UGV 1 von Einsatzleiter	TurnAssign
+UGV-1	ich wollte jetzt mit dem UGV 1 nach oben ins Obergeschoss versuchen weil da wollte der Tim hin und konnte nicht weiter erkunden, wenn das okay ist	Offer
+UGV-2	Teamleiter von UGV-2	TurnAssign
+UGV-1	UGV 1 hört	TurnAccept
+UAV	UAV hört	TurnAccept
+UAV	Hier UAV operator	TurnAccept
+TL	Teamleader hört	TurnAccept
+UGV-1	die westliche Richtungserkundung auf dieser Ebene?	Question
+TL	Teamleader hört kommen	TurnAccept
+UGV-2	UGV-2 hört dich auch	TurnAccept
+TL	UGV 2 von Teamleader, kommen	TurnAssign
+UAV	hier ist Dirk	TurnAccept
+UGV-2	Roboter 2 hat verstanden	AcceptRequest
+UGV-1	ich höre dich	TurnAccept
+UAV	ja, das habe ich verstanden	AcceptRequest
+UGV-1	hier Operator 1	TurnAccept
+UGV-2	Teamleader von UGV 2	TurnAssign
+UGV-1	Teamleader von UGV-1 kommen	TurnAssign
+TL	ja	TurnAccept
+TL	baldmöglich erstes Bildmaterial senden	Request
+UGV-1	bis dato noch nicht	Disconfirm
+TL	Lena für Benno	TurnAssign
+UAV	UAV ist wieder einsatzbereit	Inform
+TL	Bleib mal gerade an der Position wir starten dich noch gerade neu	Request
+UGV-2	Sicht ist relativ schlecht das blendet stark	Inform
+UAV	ich hab dir nochmal ein Bild ein herangezoomtes Bild geschickt, wo der Qualm besser zu sehen ist, aber keine Personen gefunden, von dieser Position aus	Inform
+UAV	ja, ist verstanden	Confirm
+TL	hier Markus verstanden	Auto-positive
+TL	UGV-2 von Teamleiter	TurnAssign
+TL	Nimm doch mal bitte einen Rundblick	Request
+TL	ja richtig	Allo-positive
+TL	auf welchem Bild jetzt auf einem Wärmebild oder auf einem richtigen Foto?	ChoiceQuestion
+TL	ja, verstanden	Auto-positive
+UGV-2	Teamleiter von UGV-2	TurnAssign
+TL	Verbindung ist aber immer noch sehr schlecht	Inform
+UGV-1	ich fahr mal näher ran und erkunde	AddressRequest
+TL	UGV 1, UGV 2 seid ihr startklar?	PropositionalQuestion
+UAV	ich hab dir - oder ich schick dir gleich nochmal ein Bild rüber, du siehst auf der Rückseite definitiv zwei Orte, wo sich noch Glutnester befinden	Offer
+TL	Thorsten hört kommen	TurnAccept
+TL	UGV-1 von Teamleiter	TurnAssign
+UGV-1	Ja im letzten Foto das ich geteilt habe ich versucht die Probenentnahme zu fotografieren kommen	Inform
+UGV-2	ja, ich hab ein grünes Fass ausgemacht, und Rauch	Inform
+TL	ja	Auto-positive
+TL	UAV von Einsatzleiter	TurnAssign
+TL	nächster Auftrag weitere Personensuche	Request
+TL	Jetzt neuer Bericht von Gasgeruch in der Mitte des Gebäudes	Inform
+UAV	ja, ich guck mal gleich wieder	Confirm
+UAV	auf der Etage wo die Personen gefunden wurden befindet sich ein 200-Liter-Gefahrstoffbehälter Kennzeichnung umweltgefährdend	Inform
+TL	hört	TurnAccept
+TL	Ja ich guck's mir an	Promise
+TL	okay	Auto-positive
+TL	warten	Pausing
+TL	ich höre	TurnAccept
+UGV-1	UGV 1, verstanden	Auto-positive
+TL	ja, verstanden	Auto-positive
+TL	ist das der, der von dir weiter entfernt ist?	PropositionalQuestion
+TL	hier Markus verstanden	Auto-positive
+TL	du hattest mich angesprochen?	TurnAssign
+TL	ja, wie groß sind die brennenden Punkte, oder die Brandherde, was ist an Kräften erforderlich?	Question
+TL	ja, verstanden	Auto-positive
+TL	Sie suchen die nördliche Gebäudewand in westlicher Richtung ab	Request
+TL	Verstanden	Auto-positive
+TL	Kannst du mir mal grob deine Position auf der Karte durchgeben?	Request
+TL	aber sehr vorsichtig beim Vorgehen	Request
+UGV-1	ja, ich komme nicht weiter höher ins Obergeschoss ohne dass ich eine Absperrung durchfahre	Inform
+TL	hat zwar alles hier eine andere Farbe aber das Fass selber ist grün	Inform
+TL	UGV-1 von Teamleiter	TurnAssign
+TL	hört	TurnAccept
+TL	Ja verstanden	Auto-positive
+TL	UGV 1, kommen	TurnAccept
+UAV	hier ist die UAV	TurnAccept
+UGV-1	ja, Einsatzleiter von UGV 1, kommen	TurnAssign
+UGV-2	ja, es geht weiter	Inform
+UGV-1	Einsatzleiter von UAV 1	TurnAssign
+UGV-1	Rechtseitig ein blaues Fass mit ner undefinierten Aufschrift gefunden	Inform
+UGV-2	das müsste irgendwo im westlichen Bereich sein	Inform
+TL	Du machst mir jetzt ein Foto dann gucken wir	Request
+UAV	Ich habe ein Übersicht ein Übersichtsfoto geshared von ungefähr der Position Tango ASA 352	Inform
+TL	wenn du jetzt startest, den Hochofen, der von euch weiter weg ist - von dort aus hätte ich gerne Bilder aus der Mitte zwischen den Hochöfen	Request
+TL	Das ist so korrekt	Inform
+UGV-1	Teamleader von UGV 1	TurnTake
+UAV	welcher Gebäudeteil soll umflogen werden?	SetQuestion
+TL	die Drohne ist auch einsatzbereit?	PropositionalQuestion
+TL	und dort finden Sie Rettungskräfte die Orientierungsprobleme haben um an die verunfallte Person zu gelangen kommen	Inform
+UGV-2	Daniel hat verstanden	Auto-positive
+UAV	Personensuche aus der Luft mittels Wärmebildkamera verstanden	AcceptRequest
+TL	UGV-1 von Teamleader Leiter	TurnAssign
+UAV	die Drohne fliegt	Inform
+TL	Ihr könnt also Fotos schicken ich sehe auch eure Position live	Inform
+UGV-1	Teamleader, UGV 1	TurnAssign
+TL	ja, richtig	TurnTake
+UGV-2	Daniel hört	TurnAccept
+UAV	Einsatzleiter von UAV	TurnAssign
+TL	ich werte das Bild aus	Promise
+UGV-2	ja, wie so 'ne Stahltreppe halt aussieht, ne biegt erst mal einer nach oben weiter konnte ich nicht sehen, weil meine Kamera nicht höher ge-	Inform
+TL	Hey ja	Confirm
+UGV-2	UGV-2 hört dich	TurnAccept
+UGV-1	ja, 50 meter geradeaus, links rein und erkunde nach Menschen	AcceptRequest
+TL	Operator 1 für Teamleader, kommen	TurnAssign
+TL	Operator 2 für Teamleader, kommen	TurnAssign
+UAV	Teamleader von UAV operator kommen	TurnAssign
+TL	wie sieht's bei euch aus, geht gar nichts mehr, oder seid ihr wieder im Spiel?	ChoiceQuestion
+UAV	ja, ist negativ	DeclineRequest
+UAV	Aber du wirst keine Updates kriegen	Inform
+UAV	ja, ist verstanden	Auto-positive
+UGV-1	da, das ist korrekt	Allo-positive
+TL	gab es Möglichkeiten eine Etage weiter nach oben zu kommen?	PropositionalQuestion
+TL	warte, ich muss eben erst gucken	AddressOffer
+UGV-2	UGV-2 hört	TurnAccept
+TL	Teamleader hört	TurnAccept
+UAV	UAV auch verstanden	Auto-positive
+UGV-2	ich bin gerade dabei, einfach schon mal Richtung den Weg zu kommen, wo der Operator 1 lang gefahren ist	Answer
+TL	ja, ich höre	TurnAccept
+TL	Haben Sie das Foto bereits geteilt?	PropositionalQuestion
+TL	ja, richtig	Confirm
+TL	Und weiter mappen	Request
+TL	ja, verstanden	Auto-positive
+UGV-1	Einsatzleiter von UGV 1	TurnAssign
+TL	ja, macht ihr mal	AcceptOffer
+TL	also gehfähige Personen im Gefahrenbereich?	CheckQuestion
+TL	hab verstanden	Auto-positive
+UAV	so machen wir das	AcceptRequest
+TL	ja verstanden	Auto-positive
+UGV-2	ja, von meiner jetztigen Position aus ist quasi aus der Halle raus kein Rauch und keine Gefahren zu erkennen	Inform
+TL	verstanden	Auto-positive
+TL	wo ist dein Standort im Moment?	SetQuestion
+TL	Operator 1 für Teamleader, kommen	TurnAssign
+TL	UAV für Einsatzleitung kommen	TurnAssign
+TL	ja, bleib mal da, wo du jetzt bist	Request
+TL	UAV Drohne	TurnAssign
+UAV	Verstanden	AcceptRequest
+UGV-1	Teamleader von UGV-1 kommen	TurnAssign
+UAV	Thorsten für Dirk	TurnAssign
+TL	also es handelt sich um eine Person richtig?	CheckQuestion
+UAV	Das letzte Foto das ich geshared habe?	CheckQuestion
+UGV-1	ja, ich hab das Fass jetzt gedreht, man kann jetzt die Signatur des Fasses erkennen Gefahrzettel	Inform
+UGV-2	bin auf dem Treppenabsatz aber weiter links gelegen	Answer
+TL	ich höre	TurnAccept
+UGV-1	Hier ist UGV-1	TurnAccept
+UGV-1	reichen dir die Bilder? dann würde ich die Erkundung auf dieser Ebene weiter fortsetzen	PropositionalQuestion
+TL	verstanden	Auto-positive
+TL	Negativ	DeclineOffer
+TL	der Angriffstrupp musste raus, der hatt' keine Luft mehr, den Raum weiter erkunden	Inform
+TL	Dirk kommen	TurnAccept
+TL	Höre	TurnAccept
+TL	ja, richtig	AcceptOffer
+UGV-2	so, der Benno für Operator 2, kommen	TurnAssign
+UAV	ist das ein Foto von mir?	PropositionalQuestion
+TL	Andreas kommen	TurnAccept
+TL	Roboter 1 und Roboter 2 ich habe hier zwei Fotos, auf einem Foto ist ein Wärmebild da kann sich eine am Boden liegende Person befinden	Inform
+TL	ja, verstanden	Auto-positive
+UAV	also keine Suche nach Vermissten mehr?	AddressRequest
+TL	Andreas kommen	TurnAccept
+UGV-1	hier Andreas kommen	TurnAccept
+UGV-2	immer noch nicht klar	Answer
+TL	ja verstanden	Auto-positive
+UAV	ja, wir gucken jetzt gerade aus nördlicher Richtung, oder auf den Hochofen, ja	Confirm
+UAV	Aber wir werden's mal versuchen	Offer
+UGV-1	ja, ich hab dir jetzt erneut das Foto geschickt	Inform
+UGV-2	Teamleader von UGV 2	TurnAssign
+TL	Kannst du mal abschätzen wie weit du bis jetzt gefahren bist?	Request
+TL	Frage Ihr Standort immer noch mittig in der Halle oder inzwischen weiter in Richtung Westen	ChoiceQuestion
+TL	Ja verstanden	Auto-positive
+TL	negativ	DeclineOffer
+TL	Höre	TurnAccept
+TL	ja, verstanden	Auto-positive
+UGV-1	Teamleader von UGV 1	TurnTake
+UAV	wir steigen nochmal auf und gucken uns das nochmal an	Offer
+UGV-2	es gab einmal eine Treppe, da stand 'n Schild kein Durchgang, dann bin ich natürlich nicht hochgefahren	Inform
+TL	ja, verstanden	Auto-positive
+UAV	Einsatzleiter von UAV	TurnAssign
+TL	neuer Auftrag ist: Akku tauschen, damit die Drohne wieder fliegen kann	Request
+TL	Wo ist gerade dein Standort?	SetQuestion
+UAV	wir haben auch gerade mal zwei Bilder gemacht	Inform
+TL	ist das der Mensch, der da an einem Pfeiler hockt?	PropositionalQuestion
+TL	ja, verstanden	AcceptOffer
+UAV	Teamleiter von UAV	TurnAssign
+TL	kann man es denn manuell nicht beheben?	PropositionalQuestion
+TL	UGV-1 für Einsatzleiter	TurnAssign
+UGV-2	Einsatzleiter von UGV 2	TurnAssign
+UGV-1	UGV 1 hört	TurnAccept
+TL	ich höre	TurnAccept
+UGV-2	in dem Bereich befinde ich mich	Inform
+UAV	also, aufgrund der Wetterlage wäre jetzt ein Inspektionsflug möglich	Inform
+TL	ja, dann könnt ihr direkt mal erkunden wie aus der Position, wo UGV zw- eins sich momentan befindet, das andere Fass zu sehen war	Request
+UAV	ich habe jetzt bei der zweiten Person auch eventuell Rauch gefunden	Inform
+TL	Höre	TurnAccept
+TL	Gut das heißt du kannst dich jetzt ja gar nicht bewegen?	Auto-positive
+UGV-2	ja, Foto kommt	AcceptRequest
+UGV-1	Tim, bist du so 'nen Gang entlang gefahren?	PropositionalQuestion
+TL	Lena, dann flieg mal mit deinem Fluggerät da weiter ja, weiter nach rechts, würde ich jetzt erst mal sagen, was immer auch rechts sein mag so wie du jetzt guckst quasi in deiner Position in Richtung deiner Position	Instruct
+UGV-2	Ja ist verstanden	AcceptRequest
+UAV	wir müssen gerade den Akku tauschen	AddressRequest
+TL	ich höre	TurnAccept
+UGV-1	müsste ein blauer Kanister sein	Inform
+TL	Ja verstanden dann für euch Ende der Mission	Auto-positive
+UGV-1	Ich habe hier eine Erkenntniss hier ist ein Feuerlöscher fehlt	Inform
+TL	Das ist verstanden	Auto-positive
+UAV	ja, das habe ich verstanden	Auto-positive
+UAV	das ist verstanden wir schalten um auf Wärmebild und gucken	AcceptRequest
+TL	Konntest du schon mal was erkennen sind die Behälter dicht oder undicht?	Question
+UAV	das hab ich auch verstanden	AcceptRequest
+TL	Und konntest du irgendwelche Markierungen darauf erkennen oder Schilder?	Request
+TL	Für Sie Auftrag Sie sind mit Messgeräten zur Gasmessung ausgestattet alle 15 Minuten die Gaskonzentration messen	Request
+TL	Operator 2 für Teamleader	TurnAssign
+UGV-2	ja, verstanden	Auto-positive
+UAV	UAV operator	TurnAccept
+TL	Dirk von Thorsten kommen	TurnAssign
+UGV-2	UGV 2 gerufen?	TurnAccept
+UGV-1	UAV 1 von UGV 1	TurnAssign
+TL	Wie ist der Status?	Question
+UGV-1	ja, ich hab ein weiteres grünes Fass gefunden beim Erkunden der Treppe gefunden in der Nähe von dem anderen aufrecht stehenden Fassfestzustellen	Inform
+UGV-1	Markus von Andreas kommen	TurnAssign
+UGV-1	Teamleader von UGV 1	TurnAssign
+TL	verstanden	Auto-positive
+TL	UAV operator von Teamleader	TurnAssign
+UGV-1	Es befindet sich schon mal links ein Gefahrgutfass Ölfass	Inform
+TL	Teamleiter	TurnAccept
+TL	ja das ist gut zu wissen verstanden	Auto-positive
+UGV-2	Erstellen einer Lage einer Karte des länglichen Gebäudes verstanden	Auto-positive
+UGV-1	hier Operator 1	TurnAccept
+UGV-2	UGV-2	TurnAccept
+TL	Möglichkeiten, mit dem Bodenroboter da hochzufahren?	Question
+UGV-2	immer noch in der Nähe des grünen Fasses, aber hier geht im Moment nichts	Answer
+TL	ja, ich höre	TurnAccept
+TL	der Angriffstrupp steht an der Rauchentwicklung	Inform
+UAV	Behältnis scheint dicht zu sein	Inform
+UGV-1	Foto ist versandt	AddressRequest
+TL	ich gucke	Promise
+TL	ja, verstanden	Auto-positive
+UGV-1	Sehe den Tango rechtseitig vor mir	Inform
+UAV	Einsatzleiter von UAV	TurnAssign
+UGV-2	ne, ich kann hier nichts machen, es sind ja mit drei, vier Technikern die ganze Zeit am PC zugange	Disconfirm
+UAV	ich schick dir jetzt noch mal ein Bild von weit oben rechts auf dem Bild, was nicht mehr zu sehen ist, sind diese drei klein' Hochöfen und links ist der ganz große gefüllte Hochofen	Offer
+TL	Dass du dass du mal ein Foto machst du auf Höhe von ASA 310	Request
+TL	ich hab im Moment keinen Roboter einsatzbereit kannst du gucken, ob du dieses Fass findest und entsprechende Bilder machst?	Inform
+UGV-1	UAV 1 von UGV 1	TurnAssign
+UGV-1	Aber die nördliche Wand besaß kein Zugang	Inform
+UGV-1	Bild müsste da sein ja	Confirm
+TL	schwenk mal nach rechts dann müsstet ihr eigentlich in die Halle reinblicken	Answer
+TL	ich hoffe ihr habt auch eine Landmarke gesetzt	Request
+UAV	ja, verstanden	Auto-positive
+UGV-2	UGV 2 hört	TurnAccept
+TL	ich höre	TurnAccept
+TL	Lena, du hast alle Fotos jetzt von einer Stelle aus gemacht	Inform
+UGV-1	es handelt sich um ein 200-Liter-Fass	Inform
+UGV-1	das war Roboter 1	Answer
+TL	Habt ihr den Standort geteilt?	PropositionalQuestion
+TL	So weiteren Einsatzauftrag erhalten folgende Lage grundsätlich die Lage die selbe wie heute morgen Explosion in diesem länglichen Gebäude unklare Ausdehnung	Inform
+TL	Wie ist der Zustand des Fasses?	Question
+UGV-1	ja, wir stehen hier wohl auf einer Rampe, ich kann nämlich genau sagen wo die ist	Inform
+UAV	Mein Standard ist im Moment Position ECO	Confirm
+UGV-1	Rechts von mir sehe ich den Ölfass	Inform
+TL	ja, verstanden	AcceptOffer
+UGV-1	Hier ist UGV-1	TurnAccept
+UAV	UAV landet	Inform
+UGV-1	ich muss mich erst mal orientiere und gucken, ob ich irgendwo hochkomme	Answer
+TL	UGV 1 von Teamleader	TurnAssign
+UGV-1	Okay ja	AcceptRequest
+UGV-1	geht's einmal die Treppe noch weiter hoch oder soll ich in der Ebene bleiben und nach weiteren Räumen suchen?	ChoiceQuestion
+TL	verstanden	Auto-positive
+UAV	Zur Information eine Person im oberen Gebäudeteil identifiziert und ein Chemikalienfass	Inform
+UGV-1	ja, verstanden	Auto-positive
+TL	noch suchen nach weiteren Personen	Answer
+TL	viel Erfolg mit dem Treppenbesteigen?	Question
+UGV-1	ich bin eine Etage hochgefahren als den Startgang ganz durch dann links ein Stockwerk gewechselt	Inform
+UAV	Ja ich hab dir die vermutliche Position die mögliche Position vom Opfer und dem Chemikalienfass geschickt	Inform
+UGV-1	verstanden	Auto-positive
+TL	Nicht gerade	Pausing
+TL	ich höre	TurnAccept
+TL	Wenn Sie sich an der nördlichen Gebäudewand entlang nach Westen bewegen nehmen sie immer so den Victim als Ziel	Instruct
+TL	ja, ich melde mich gleich	Pausing
+UGV-1	ja Andreas kommen	TurnAccept
+TL	ihr seid also jetzt den eigentlichen Hochofenbereich abgeflogen, komplett, ja?	CheckQuestion
+UAV	Markus für Dirk	TurnAssign
+TL	Operator 1 und 2 für Teamleader, kommen	TurnAssign
+UAV	UAV	TurnAccept
+TL	UAV von Einsatzleiter	TurnAssign
+UGV-1	ja, der Operator 1 hört	TurnAccept
+UAV	ja, das ist richtig	Confirm
+UGV-2	und hab große Aussetzer 	Answer
+TL	wie sieht's aus, könnt ihr fliegen?	PropositionalQuestion
+TL	UGV-2 von Einsatzleiter	TurnAssign
+UAV	es könnten Personen sein das was hell leuchtet	Inform
+UGV-1	ich stehe vor dem Fass, so kannst du auf deiner Seite bleiben	Inform
+TL	in der Zwischenzeit schon irgend etwas an Personen festgestellt oder Lageveränderungen?	Question
+UAV	Einsatzleiter von UAV	TurnAssign
+UAV	der Einsatleiter vom Operator UAV, kommen	TurnAssign
+UGV-1	der Teamleader von Operator 1, kommen	TurnAssign
+UGV-1	Ja ist mittig in der Halle	Answer
+UGV-1	ja, ist verstanden	Auto-positive
+UGV-2	ich komme gleich mit 'nem neuen Bild	Promise
+UAV	also, ich kann auch hier keine Glutnester erkennen	Inform
+TL	UGV 2 von Einsatzleiter	TurnAssign
+Speaker	Dialogue Turn Text	Communicative Function
+TL	phantastisch	Auto-positive
+UGV-1	UGV 2 von UGV 1	TurnAssign
+TL	das ist verstanden	Auto-positive
+UGV-1	wir machen jetzt erst mal noch eine Zwischenlandung für einen Akkuwechsel	Inform
+UGV-1	Ja die nördliche Wand kann ich gar nicht erreichen ich kann höchstens den UGV-2 folgen	Disagreement
+TL	Maßnahme momentan: warten, wir machen hier gerade Übergabe	Request
+TL	ihr setzt die Erkundung in östlicher Richtung weiter fort	Auto-positive
+UGV-2	ja, ich schick dir gleich ein Bild von UGV 1, wenn er an mir vorbei fährt	AcceptRequest
+UGV-1	noch als Zusatz, dieses Fass scheint nicht auszulaufen	Inform
+TL	UGV 1 von Teamleader, kommen	TurnAssign
+TL	Teamleader an alle	TurnTake
+TL	UHV Operator für Teamleader, kommen	TurnAssign
+TL	ja, richtig	TurnTake
+UAV	möchtest du normale oder Infrarot-Bilder haben?	ChoiceQuestion
+UGV-1	ja, das kann ich versuchen	AcceptRequest
+TL	okay	Auto-positive
+TL	nach oben?	CheckQuestion
+TL	Unsereines Auftrag Gasquelle lokalisieren	Request
+TL	mach mal bitte an den relevanten Punkten Fotos, dass wir den hinterher nachvollziehen können	Request
+TL	Ich habe jetzt wieder Connection zur Datenbank	Inform
+TL	Für Sie kurze Lageinformation es gab einen Unglücksfall in dem länglichen Graphecs Gebäude Luftbildaufnahmen sagen dass es unstabil und unsicher für Personen ist	Inform
+UAV	die Drohne hört	TurnAccept
+TL	Ja verstanden	Auto-positive
+UGV-2	das Bild ist geteilt	Inform
+TL	UGV 1 von Teamleader, kommen	TurnAssign
+TL	immer noch Menschen suchen, ne	Request
+UGV-1	ich hab 'nen weiteren Kanister gefunden, weiß	Inform
+TL	neuer Auftrag Personsuche aus der Luft mittels Wärmebildkamera kommen	Request
+TL	UGV-1 von Teamleiter	TurnAssign
+UGV-2	Kann ich ein Snapshot von der linken Seite machen weißt du das?	CheckQuestion
+TL	Lena für Benno?	TurnAssign
+TL	verstanden	Auto-positive
+TL	Geh einfach weiter vor wir versuchen das Problem hier zu lösen	Request
+UGV-2	ja	AcceptRequest
+UGV-2	ja, negativ, ich hab hier gerade Probleme mit mir selbst	Disconfirm
+TL	ja, jetzt haben wir die Erkundung der rückwärtigen Seite in nördlicher Bereich	Request
+TL	ich höre	TurnAccept
+UGV-1	ja, ich rolle bereits	Confirm
+UAV	sollen wir loslegen, und erkunden? oder hast du noch was?	ChoiceQuestion
+UGV-2	ja, ich kann das mal probieren	AcceptRequest
+TL	UGV-1 von Teamleiter	TurnAssign
+UAV	ich habe ein Infrarotbild geschickt da sind zwei Personen zu sehen jetzt nähert sich dort eine dritte	Inform
+UGV-2	wir sind noch in der Nähe von dem ersten Behälter, der von UGV 1 untersucht wurde	Answer
+UAV	ich schick das Foto	Offer
+UGV-1	Teamleader von UGV-1 kommen	TurnAssign
+TL	UGV-1 für Einsatzleiter	TurnAssign
+TL	Andreas von Markus kommen	TurnAssign
+TL	Dirk von Markus kommen	TurnAssign
+TL	hier Markus verstanden	Auto-positive
+TL	Wo ist dieser eine Eingang jetzt genau ist der praktisch südlich von ASA 310?	Question
+TL	Thorsten hört kommen	TurnAccept
+UGV-1	Ja ich hab hier keine Reaktion bei dem Roboter und keine Verbindung mehr zur Datenbank	Inform
+UAV	ich hab ein Bild jetzt geschickt auf einem Behältnis oben eine helle Person	Inform
+TL	Thorsten hört kommen	TurnAccept
+UAV	das ist korrekt	Allo-positive
+UAV	Benno für Lena	TurnAssign
+TL	könnten - darauf kann ich sehen, wo der Standort ist?	Retraction
+UGV-1	Einsatzleiter von UGV 1	TurnAssign
+TL	ja, verstanden	Auto-positive
+TL	Wenn du da nichts entdeckst weiter Richtung Osten	Instruct
+UAV	da bewegt sich das erdgebundene Fahrzeug gerade darauf zu	Inform
+UAV	und das Bild hängt	Inform
+TL	ich höre	TurnAccept
+UAV	hier ist Dirk	TurnAccept
+UAV	ich hab zwei Bilder gerade geschickt das eine mit vier Personen die alle gehfähig sind	Inform
+TL	Operator 1, schickst du mir das nochmal rüber, ich habe nichts gekriegt hier	Request
+UGV-1	Teamleiter von UGV-1 kommen	TurnAssign
+TL	ja, ich melde mich sofort	Auto-positive
+UGV-2	wir haben gerade ein kleines technisches Problem, ich melde mich gleich	Inform
+TL	ja, dann fahrt mal hoch und erkundet da weiter	AcceptOffer
+TL	UGV-2 von Teamleiter	TurnAssign
+TL	ja, Bild ist angekommen	Confirm
+UAV	UAV ist wieder startbereit	Inform
+TL	Okay konntest du denn eine Probenahme beenden?	Auto-positive
+TL	UGV-1 UGV-2 und UAV kommen	TurnAssign
+UGV-1	ich habe die Nebelmaschine gefunden	Inform
+UGV-1	ja, der Kanister wurde jetzt von allen Seiten begutachtet, Kanister ist verschlossen keine Gefahr und Piktogramme auf dem Kanister	Inform
+UGV-1	Frage: Raum weiter erkunden?	Offer
+UAV	wir sind jetzt wieder startklar	Inform
+UGV-2	ja, ich habe nochmal ein Foto gezeigt	Inform
+UGV-1	Ja ich hab dir jetzt mal ein Foto von meinem Standort geschickt	Inform
+UGV-2	Ich seh einen Roboter aber das wird aufgrund der Beschreibung nicht der Roboter sein	Answer
+TL	Dirk von Markus kommen	TurnAssign
+UGV-1	Ja ich gehe jetzt vor zu UGV-2 und versuch die Probenentnahme zu fotografieren kommen	AcceptRequest
+TL	UAV von Einsatzleiter	TurnAssign
+Speaker	Dialogue Turn Text	Communicative Function
+UGV-1	ja, ist verstanden, ich mach hier Fotos	AcceptRequest
+TL	das ist verstanden	Auto-positive
+UAV	Dirk hat verstanden	Auto-positive
+TL	UGV-1 von Teamleader	TurnAssign
+TL	wie ist der Stand der Dinge?	Question
+UAV	UAV hört	TurnAccept
+TL	mach mal ein Foto	Request
+TL	Lena für Benno?	TurnAssign
+UAV	ich habe ein Objekt von dem Rauch austritt	Inform
+TL	Teamleader hört kommen	TurnAccept
+UGV-1	gefühlte 10 bis 20 meter	Answer
+UAV	kannst du die Bilder sehen? UGV?	PropositionalQuestion
+UAV	hier ist UAV	TurnAccept
+TL	UAV 1 von Teamleader, kommen	TurnAssign
+UGV-2	negativ	Disconfirm
+UAV	nein ich habe zur Zeit überhaupt kein Bild von der Drohne	Inform
+UAV	Thorsten für Dirk	TurnAssign
+TL	UAV Drohne	TurnTake
+UGV-1	ja, das habe ich gemacht	Answer
+TL	ja, machen wir so	Agreement
+UGV-2	Roboter 2 hat verstanden Übungsende	Auto-positive
+TL	Daniel von Markus kommen	TurnAssign
+UAV	Über dem Zustand der Person keine weiteren Erkenntnisse zu bekommen	Inform
+UGV-1	ich habe dir gerade noch ein Foto von dem grünen Gefahrgutbehälter 200 liter rübergeschickt	Inform
+UAV	Teamleader von UAV operator kommen	TurnAssign
+TL	kannst du mir weitere Details zu dem liegenden Fass geben? eine Nummer, zum Beispiel?	Request
+TL	Ich kann Sie nicht aufnehmen, wiederholen	Auto-negative
+TL	konntet ihr im Außenbereich noch weitere Fässer feststellen, oder war's das einzigste?	PropositionalQuestion
+TL	verstanden	Auto-positive
+TL	Teamleader hört	TurnAccept
+TL	verstanden	Auto-positive
+UGV-2	UGV-2	TurnAccept
+TL	Frage: Standort Roboter?	Question
+TL	Ich gucke mir erst mal an	Promise
+UAV	ich erkunde das Umfeld weiter	Offer
+TL	Ja	Auto-positive
+UGV-2	und da bin ich auf einer Seite vom Geländer, ich umfahre jetzt diese Bullaugen und müsste dann direkt vor dem Fass stehen	Inform
+TL	ich höre	TurnAccept
+UGV-1	soll ich meinen Erkundungsbefehl fortsetzen oder beginnen?	ChoiceQuestion
+TL	Andreas von Markus kommen	TurnAssign
+UGV-1	ich kann nur bestätigen, UN-Nummer 12 03, Gefahrenzettel leicht entflammbar und umweltgefährdend	Inform
+UGV-2	UGV 2 hört	TurnAccept
+UGV-2	ja, mein Roboter hier, der hat jetzt ne Kette fast verloren	Answer
+TL	ja, verstanden	Auto-positive
+TL	ich höre	TurnAccept
+UGV-1	habe Standort nochmal angefahren	Inform
+TL	hier Markus	TurnAccept
+TL	das ist korrekt	Confirm
+UGV-2	ja, das ist korrekt	Confirm
+UGV-1	ja ich kann den Standort direkt nochmal anfahren	AcceptRequest
+UAV	das ist korrekt	Confirm
+UAV	hier ist die UAV	TurnAccept
+TL	UGV 1, UGV 2	TurnTake
+TL	Lena, jetzt sag mir mal genau den Standort dieser Person	Request
+UGV-2	der Operator 2 hört	TurnAccept
+UGV-1	Ich hab die Connection zur Database verloren	Inform
+TL	schickst du mir noch mal ein aktuelles Foto euren Standortes?	Request
+TL	hattest du von dem blauen Kanister noch ein Foto gemacht?	Request
+UAV	also, derzeit sind wir nicht startbereit mit der UAV, weil es noch zu sehr regnet	Inform
+TL	könnt ihr da auch was ausmachen in Form von Wärmestrahlung?	PropositionalQuestion
+TL	Moment warten	Pausing
+TL	Übung beendet	Inform
+TL	Also ich kann keine Rauchentwicklung auf deinem Foto erkennen	Inform
+UAV	noch negativ, im Moment ist wieder zu viel Regen	Disconfirm
+TL	Jetzt hör ich dich besser	Inform
+UGV-1	ja von dem Fass	Confirm
+TL	Thorsten hört kommen	TurnAccept
+TL	die drei gehfähigen sind nah beieinander	Answer
+UGV-1	werde dies jetzt fotografieren und einmal um-kreisen, um eine Leckage 	Promise
+TL	Habt ihr neuen Status zum Standort der Person oder der Chemikalien? Ich krieg keinen Standort	Question
+UAV	Kann ich versuchen	Offer
+UGV-2	UGV 2 hört	TurnAccept
+UGV-2	soll ich in die Richtung fahren?	Offer
+UAV	ich schicke dir ein Bild	Offer
+UGV-1	Ich hab dir ein Foto gemacht	Inform
+TL	schick mir mal ein Foto, wo ihr steht, damit ich ein bisschen zuordnen kann	Request
+TL	dann Erkundung zweiter Obergeschoss	Request
+TL	jetzt gilt der Auftrag auslaufende Chemikalien und Gefahrstoffe zu finden und zu orten	Request
+TL	Ja verstanden	Auto-positive
+TL	UAV operator von Teamleiter	TurnAssign
+UGV-1	hab dir jetzt ein Übersichtsfoto geschickt von einmal den blauen Kanister und dem grünen Fass mit der grünen Flasche drauf	Inform
+TL	ja, insbesondere was die Wärmeentwicklung geht anbetrifft, da konnte man nicht viel erkennen	Request
+TL	UGV-1 kommen Sie	TurnAccept
+UAV	ich schick dir eben noch zwei andere Fotos, da müsstest du es besser erkennen das ist könnte aber eventuell eine andere Person sein	Promise
+UAV	ja, ist verstanden	AcceptRequest
+UGV-1	ich bin gerade dabei	AddressRequest
+UGV-2	Das ist nicht erkennbar es handelt sich scheinbar um Papp-Pakete kleine	Answer
+TL	nein das ist ein Foto von dem Roboter 1	Disconfirm
+UAV	ich kann keine Rauchentwicklung erkennen	Inform
+TL	ja, korrekt	Confirm
+TL	ihr nehmt aber die westliche Richtung	Inform
+TL	das ist korrekt	Allo-positive
+UAV	Einsatzleiter von UAV	TurnAssign
+TL	ja, schickst du mir mal ein Foto?	Request
+UGV-2	Die erste Probe genommen und in den Korb abgelegt versuche jetzt die zweite auf dem Stuhl zu nehmen	Inform
+TL	Roboter 2 von Thorsten kommen	TurnAssign
+UGV-1	das Bild müsstest du schon haben	Inform
+UGV-2	ja, Operator 2 hört, Benno	TurnAccept
+TL	ich höre	TurnAccept
+UGV-1	das Thermo-Image war eher danach hab ich ein Wechsel vorgenommen um dir ein Live-Bild zu schicken	Inform
+UAV	Teamleader von UAV, kommen	TurnAssign
+UGV-1	Würd jetzt weiter geradeaus fahren und da weiter erkunden	Offer
+TL	ich melde mich sofort	Pausing
+UGV-2	Teamleader von UGV 2	TurnTake
+UGV-1	Ja ich kann dich hören	TurnAccept
+TL	Operator 1, der Angriffstrupp ist unterwegs	Inform
+UGV-2	ich hab einen großen Zeitunterschied zwischen Bewegung und Eingabe	Answer
+UGV-1	es sieht aus wie Gerolsteiner	Answer
+UGV-1	ich habe hier jetzt gerade eine Hitzequelle ausgemacht definitiv keine Person	Inform
+TL	UGV 2 von Teamleader	TurnAssign
+UGV-1	Teamleader von Roboter 1	TurnAssign
+UGV-1	Frage: ist das schon erfolgt?	PropositionalQuestion
+TL	kannst du sehen ob irgendwelches Medium ausläuft?	Question
+TL	Standort, Frage?	Question
+TL	bewegt ihr euch mal in südlicher Richtung und sucht das Gelände mal nach gefährlichen Stoffen ab? kommen	Request
+UGV-1	der Teamleader von Operator 1	TurnAssign
+TL	der Einsatz-Auftrag ist unverändert Erkundung nach Personen	Inform
+TL	höre	TurnAccept
+TL	ja, verstanden	Auto-positive
+TL	Höre	TurnAccept
+UGV-2	UGV-2 hat sich nur ein meter fortbewegt damit UGV-1 da weg kommt	Answer
+TL	Foto machen geht auch nicht?	CheckQuestion
+TL	bleibt mal auf der Ebene und fahrt weiter in westlicher Richtung, und erkundet dort	Instruct
+TL	UAV Drohne?	TurnAssign
+UGV-2	ja, UGV 2, ich dreh dann um und erkunde die andere Gebäudeseite	Offer
+UGV-2	Zur Info ich hab keinen Kontakt zu meinem Roboter	Inform
+TL	verstanden Roboteraussetzer	Auto-positive
+TL	UAV operator von Teamleader	TurnAssign
+TL	Höre	TurnAccept
+UAV	also, wir haben jetzt doch eine leichte Rauchentwicklung auf der nördlichen Seite des Gebäudes	Inform
+UGV-1	ich schicke dir gleich ein Foto	Promise
+TL	Für sie Auftrag innerhalb des Gebäudes nach Hitze- und Rauchquellen suchen	Request
+TL	alles klar	Auto-positive
+TL	von oben uns Fotos machst und guckst, wo wir 'ne Rauchentwicklung haben und auch mit der Infrarot-Kamera 	Request
+UGV-1	ich konnte beide Rauchquellen identifizieren, beides Nebelmaschinen	Inform
+UAV	Funkübertragung zur Zeit nicht möglich	Inform
+UGV-1	das ist auch meine Vermutung	Agreement
+TL	Ja verstanden	Auto-positive
+UAV	Wir versuchen davon ein Foto zu machen	Offer
+UGV-1	werde davon ein Foto machen und dir zusanden	Promise
+TL	der mittlere Gebäudeteil	Answer
+UGV-1	ja, ich hab dir ein Bild und 'ne Wärmebild von den brennenden Punkten geschickt	Inform
+UGV-1	ich bin einmal jetzt um das Gebäude rum Tim, war dat 'ne schräge Treppe	Inform
+UAV	wir sind unterwegs und melden uns gleich nochmal	Promise
+UAV	Das kann ich hier leider nicht erkennen	Inform
+TL	ich höre	TurnAccept
+UGV-2	UGV 2 hört	TurnAccept
+UGV-2	ja, ich gucke mal, dass ich dir jetzt ein Foto schicke, scheint weiter zu gehen bei uns	Promise
+UAV	ich hab dir ein Bild geschickt, was den Hochofen aus nördlicher Richtung zeigt	Inform
+UGV-1	Bild kommt gleich	Promise
+UGV-1	ja, mir ist jetzt gelungen, das Gefäß zu bergen, beziehungsweise zu drehen, werd jetzt einmal ne Rundumschau von dem Gefäß machen	Inform
+TL	ja, folgende Lage: im Bereich zwischen den Hochöfen hat es eine Explosion gegeben	Inform
+TL	als Anhaltspunkt in dem Bereich muss sich der Roboter 1 befinden kommen	Inform
+UAV	wir tauschen jetzt den Akku und fliegen dann nochmal au- aus einer anderen Richtung an	Offer
+TL	Ja verstanden	Auto-positive
+TL	Operator 2 für Teamleader, kommen	TurnAssign
+UAV	schon da	AddressRequest
+TL	weitere Erkenntnisse um das Fass herum an Leckagen? da es ja eine Explosion gewesen ist	Question
+UGV-2	aber teilweise unfähig das umzusetzen weil mein Roboter sich teilweise gar nicht bewegt	AddressRequest
+UGV-1	ich versuche jetzt zur UGV 2 zu kommen	Offer
+TL	UGV 2 von Einsatzleiter	TurnAssign
+TL	Höre	TurnAccept
+TL	ich höre	TurnAccept
+TL	ja würde ich mich darüber freuen	AcceptOffer
+UGV-1	Ja ich kann hier weiterfahren	Inform
+TL	ja, ich hätte gerne dass du mit dem Vogel da einmal über die Hochöfen fliegst, nen Rundflug machstguckst, ob du da irgendwelche Personen entdecken kannst	Request
+TL	UGV 2, wie sieht's bei euch aus? UGV 2 von Teamleader, kommen	Question
+TL	Okay d.h. wir haben beide UGV im Moment nicht einsatzbereit?	Auto-positive
+TL	höre	TurnAccept
+TL	Andreas kommen	TurnAccept
+UGV-1	der Behälter scheint leer zu sein, ich hab dir ein Bild geschickt	Inform
+UGV-1	Ja ich versuch zum Startpunkt zurückzukehren und prüfe ob Rauchentwicklung	AcceptRequest
+TL	hat er schon irgendwelche nenneswerten Erkenntnisse mit Hinblick auf besondere Gefahren oder thermische Ausbreitung?	Question
+UGV-2	UGV-2	TurnAccept
+TL	UGV 1 von Einsatzleiter	TurnAssign
+TL	wer von euch beiden hat 'n Foto gemacht auf der Treppe?	SetQuestion
+UGV-1	Teamleader von UT-1 kommen	TurnAssign
+UGV-1	Dort auch senden?	PropositionalQuestion
+TL	Frage wie ist die Situation am Roboter?	Question
+UGV-2	ja, hört	TurnAccept
+UGV-1	Frage: der Einsatzbefehl gilt auch für UGV 1?	PropositionalQuestion
+TL	UGV-2 für Einsatzleiter mitgehört?	FeedbackElicitation
+UGV-1	Teamleader von UGV 1	TurnTake
+UGV-1	Vom Startpunkt entfernt	Inform
+TL	hab ich verstanden	Auto-positive
+TL	UAV für Einsatzleiter	TurnAssign
+TL	UGV UGV-1	TurnAssign
+UAV	Benno für Lena	TurnAssign
+UGV-1	hier Andreas kommen	TurnAccept
+UGV-1	Hier UGV-1	TurnAccept
+UGV-2	hört	TurnAccept
+UGV-1	ich werde jetzt versuchen, ins Obergeschoss zu kommen	Offer
+UGV-1	aber nur ein Spritzer	Inform
+TL	Andreas mitgehört?	Feedback Elicitation
+UAV	Markus für Dirk	TurnAssign
+UAV	wir müssen jedoch nochmal wieder warten, weil noch eine Schauerwolke durchläuft	AddressOffer
+TL	Höre	TurnAccept
+TL	UGV 2 von Teamleader, kommen	TurnAssign
+UGV-1	Teamleader von UGV-1 kommen	TurnAssign
+TL	ich höre	TurnAccept
+UGV-1	das ist korrekt	Confirm
+UGV-2	können wir weiterfahren oder warten wir noch?	ChoiceQuestion
+TL	UGV 1 von Teamleader	TurnAssign
+UGV-1	kommen Sie	TurnAccept
+UGV-2	Teamleiter von UGV-2	TurnAssign
+UGV-1	kommen	TurnAccept
+UGV-1	Hier Andreas kommen	TurnAccept
+TL	Teamleiter	TurnAccept
+TL	Frage: könnt ihr den Behälter mal von einer anderen Seite anfahren und erkunden, ob er noch verschlossen ist, oder ob da irgendwas austritt?	Request
+TL	Fahr mal bitte näher daran und mach mal Foto wie er das macht	Request
+TL	Rauchentwicklung ist von dort aus auch nicht zu sehen?	CheckQuestion
+TL	schicken Sie mir das Foto?	Request
+UGV-2	Ich hab mal ein Foto gemacht das ist die Wand meines Erachtens in nördlicher Feuerlöscheinrichtung und Lagerteile an den Wänden der Regalen	Inform
+UGV-2	Frage, anderer Auftrag?	Question
+TL	und von dort geradeaus weiter auf die Person zufahren?	Request
+UGV-1	Ich kann's nicht erkennen was es ist	Inform
+UAV	UGV 1 von UAV 1	TurnAssign
+UAV	und zwar sind an dem Objekt - an der - an dem Tank selber unten links ist 'ne Wärmesignatur, möglicherweise oben am Tank rechte Seite und rechts des Tankes	Inform
+TL	kannst du mir ein Bild schicken?	Request
+UAV	hier ist die UAV	TurnAccept
+TL	UGV-2 von Teamleiter	TurnAssign
+UAV	hier Operator 1	TurnAccept
+UGV-1	scheint verschlossen zu sein, ich werd ihn jetzt mal versuchen, zu drehen um eventuell 'n Piktogramm darauf zu sehen	Promise
+UGV-1	ja verstanden ich beginne mit der Erkundung	Auto-positive
+TL	Höre	TurnAccept
+TL	der Raum ist vollständig abgesucht?	CheckQuestion
+TL	ja	Auto-positive
+UGV-1	Markus von Andreas kommen	TurnAssign
+UGV-2	sag ich mal, ne	Disconfirm
+TL	das Bild mit dem Behälter war in östlicher Richtung, war's korrekt?	CheckQuestion
+UGV-2	ja, verstanden	AcceptRequest
+UAV	Einsatzleiter von UAV	TurnAssign
+UGV-2	ja, kriegen wir auch noch einen Auftrag?	PropositionalQuestion
+UGV-1	Einsatzleiter von UGV 1	TurnAssign
+TL	ja, verstanden	Auto-positive
+TL	ja, ich höre	TurnAccept
+UGV-1	Teamleader von UGV 1	TurnTake
+TL	Ja verstanden	Auto-positive
+UAV	ja, ist verstanden, westlich über das Gelände und ein Bild schicken	AcceptRequest
+TL	höre	TurnAccept
+TL	ja - Auftrag war, sich mit dem Angriffstrupp zu treffen, zunächst	Inform
+TL	das ist verstanden	Auto-positive
+TL	ich höre, Lena	TurnAccept
+UGV-1	Einsatzleiter von UGV 1, kommen	TurnAssign
+TL	könnt ihr was erkunden, was da in lauter Rauch steht?	Question
+TL	UGV-1 für Einsatzleiter	TurnTake
+UGV-1	ja, das ist negativ	Disconfirm
+UGV-1	Teamleader von UGV 1	TurnAssign
+UAV	Teamleader von UAV operator kommen	TurnAssign
+UAV	Drohne hat verstanden Übungsende	Auto-positive
+TL	Andreas kommen	TurnAccept
+UAV	UAV hört	Auto-positive
+TL	Andreas von Markus kommen	TurnAssign
+UAV	machen wir dir fertig	AcceptRequest
+UAV	wo soll ich reinzoomen, in den - eher in den Hochofen oder genau in die Mitte?	ChoiceQuestion
+UGV-1	Einsatzleiter von UGV 1	TurnAssign
+UGV-1	Frage: zur Rauchentwicklung vorfahren?	Offer
+UGV-2	Hier UGV-2	TurnAccept
+UGV-2	Teamleader von UGV 2	TurnAssign
+TL	Teilen Sie mir bitte auch mal ein Foto in ihrer Fahrtrichtung	Request
+UAV	also, wir haben diese Ausrichtung Westen und dieses Gebäude angeguckt und konnten bisher keine Glutnester feststellen	Inform
+UGV-2	Ich versuch gleich nach dem Ablegen vom zweiten nochmal nen Blick auf den anderen zu werfen	AcceptRequest
+TL	Ja das braucht mal paar Sekunden	Disconfirm
+UGV-1	Thorsten von Andreas kommen	TurnAssign
+UGV-2	Also ich hab gerade die Rückmeldung gekriegt dass bei UGV-2 das Kamerakabel zu oft oben drumgewickelt ist und dass deshalb der Arm nicht mehr geht	Inform
+UGV-1	aber aktuell noch keine Hitze-Direktion	Inform
+UGV-1	starke Rauchentwicklung vor mir	Inform
+UGV-1	schau dir das bitte mal an, beide Bilder sind geteilt	Suggestion
+UAV	Einsatzleiter von UAV	TurnAssign
+TL	hier Markus verstanden	Auto-positive
+TL	Augenblick	Pausing
+TL	UGV 1, versuch noch in kochsweite ein bisschen nähere Ergebnisse zu kriegen	Request
+TL	Ja verstanden	Auto-positive
+UGV-2	Gucke dir mal das Bild an was gerade gekommen ist das ist rechts von meiner Position	Suggestion
+UGV-1	ja, der Bereich hinter dem Pfeiler, also hinter dem Teil, wo die Person war	Confirm
+TL	UGV 1?	TurnAccept
+UAV	Teamleader von UAV	TurnAssign
+UGV-1	rechtsseitig vom Hochofen das Ding mit den Löchern	Inform
+TL	Lena für Benno, kommen	TurnAssign
+UGV-1	ich verlasse das Erdgeschoss und gehe ins erste Obergeschoss	Inform
+TL	Auftrag ist: Erkundung nach weiteren Zugangsmöglichkeiten, nach Verletzten	Request
+UGV-1	im ersten großen Raum eine Person gefunden	Inform
+UGV-1	und eine UN-Nummer kann ich erkennen	Inform
+TL	alles klar	Auto-positive
+TL	ja umgehend beginnen ohne möglichst wenig Zeitverzögerung um eine höhere Erfolgschance zur Menschenrettung zu haben	Answer
+TL	ja, ich schau mal rein	Auto-positive
+UGV-1	Könnte linksseitig schauen ob ich nen Blick auf die auf die andere Seite bekommen kann aber der Weg wird wahrscheinlich nicht zur Verfügung stehen kommen	Offer
+UGV-1	Rauchentwicklung weiter rechts	Inform
+UGV-1	ja verstanden	Auto-positive
+TL	Und jetzt fahrt ihr beide hintereinander her zum Punkt ASA 325 - 352 danke	Request
+TL	wie ist bei dir, auch einsatzbereit?	CheckQuestion
+TL	Frage: das Bild, das ich gerade bekommen hab' ist mit Blick auf zwei runden Öffnungen, ist das richtig?	CheckQuestion
+TL	gibt es schon irgendwelche Erkenntnisse über das Ausmaß das Schadenausmaß und Gefahren?	Question
+UGV-2	Also bei mir sind zwei Fotos auf der Karte hinterlegt	Confirm
+TL	Dirk kommen	TurnAccept
+UGV-1	ich würde dann die Erkundung in östlicher Richtung auf dieser Ebene weiter fortsetzen	Offer
+TL	ja, verstanden	Auto-positive
+TL	ich will wissen, ob die das Fass noch durch die Explosion ein Wärmebaustein ist	Question
+UGV-1	Ich hab dir jetzt ein Foto von meinem Blickfeld geschickt	Inform
+TL	ja, dann tausch das Akku nochmal aus und flieg die Strecke nochmal ab	Request
+TL	Sven, Tom und Lena zur Kenntnis: der Angriffstrupp geht unter Atemschutz im Bereich zwischen den Hochöfen vor und erkundet zunächst	Inform
+UGV-1	also, ich werde das nachher nachvollziehen können	Inform
+UGV-1	Einsatzleiter von UGV 1	TurnAssign
+UGV-1	ich schick dir mal ein Bild, dass du einen Eindruck kriegst, wo ich gerade stehe	Offer
+TL	wiederholen	Auto-negative
+UGV-1	also, im Moment kann ich dazu nichts sagen	Answer
+TL	ja, das ist verstanden	Auto-positive
+UAV	Einsatzleiter von U- UAV	TurnAssign
+UGV-1	Teamleader von Roboter 1 kommen	TurnAssign
+TL	Andreas von Markus kommen	TurnAssign
+TL	und guckst, ob du von dort aus noch Personen erkennen kannst	Request
+TL	Ja das ist erst mal verstanden	Auto-positive
+UGV-1	Ja verstanden	Auto-positive
+UAV	Einsatzleiter von UAV	TurnAssign
+TL	Also sieht so aus als hätte gerade ich gar keine Connection zur Database	Answer
+UGV-1	Kann ich nicht bestätigen	Answer
+UGV-2	Einsatzleiter von UGV 2, kommen	TurnAssign
+TL	höre	TurnAccept
+TL	ich höre	TurnAccept
+TL	so, der Benno an alle	TurnTake
+UAV	so wie ich das gerade gesehen hatte war da noch ein Kopf zu sehen	Inform
+TL	Wechsel des Leaders	Inform
+TL	Augenblick	Pausing
+UGV-1	hab auch davon ein Foto gemacht und dir zugesandt	Inform
+TL	UGV-1 von Teamleiter	TurnAssign
+TL	verstanden	Auto-positive
+UGV-2	ich hab gerade ein Bild hochgeladen das müsstest du sehen	Inform
+UGV-1	Ja ich erkunde dann weiter geradeaus kommen	Offer
+UGV-1	Moment mal, bitte	Pausing
+TL	wiederholen	Auto-negative
+UAV	die Wärmesignaturen sind schwarze Punkte	Inform
+TL	Deine Position auf meiner Karte hat sich kaum geändert	Inform
+TL	Ist das schlimm?	Question
+UGV-1	keine Leckage, aus dem Fass läuft nichts aus	Inform
+TL	ja, verstanden	Auto-positive
+UGV-1	ich hätte jetzt die Möglichkeit, auch in die erste Ebene hochzufahren	Offer
+TL	hab gerade gehört Feuer soll aus sein	Inform
+TL	Frage kannst du den anderen Roboter sehen?	Question
+UGV-1	Markus von Andreas	TurnAssign
+TL	vier Bilder 360-Grad-Abdeckung	Request
+UAV	Einsatzleiter von UAV	TurnAssign
+TL	Dirk von Thorsten kommen	TurnAssign
+UGV-2	UGV 2 hört	TurnAccept
+UGV-1	es handelt sich um die UN-Nummer 12 03 moment	Inform
+UGV-1	ja verstanden	Auto-positive
+UAV	kannst du jetzt nochmal genau beschreiben, wo ich hinfliegen sollte?	Request
+UGV-2	Roboter 2 hat gehört	Auto-positive

--- a/original_finetuning_for_intents/finetune_tradr.py
+++ b/original_finetuning_for_intents/finetune_tradr.py
@@ -1,0 +1,596 @@
+#!/usr/bin/env python
+
+# Usage example:
+# Fine-grained ISO-based annotations:
+# $ python3 finetune_tradr.py --data_dir=data_iso --mode=speaker --iso_labels=True
+# $ python3 finetune_tradr.py --evaluation=True --data_dir=data_iso --mode=speaker --output_dir=outputs/8 --iso_labels=True
+
+# Coarse-grained Einsatzbefehl-based annotations:
+# $ python3 finetune_tradr.py --data_dir=data_einsatzbefehl --mode=speaker
+# $ python3 finetune_tradr.py --evaluation=True --data_dir=data_einsatzbefehl --mode=speaker --output_dir=outputs/8
+
+import argparse
+import csv
+import logging
+import os
+import random
+import sys
+
+import numpy as np
+import torch
+from sklearn.metrics import f1_score
+from torch.nn import CrossEntropyLoss
+from torch.utils.data import DataLoader, RandomSampler, SequentialSampler, TensorDataset
+from torch.utils.data.distributed import DistributedSampler
+from tqdm import tqdm, tqdm_notebook, trange
+from transformers import (
+    WEIGHTS_NAME,
+    AdamW,
+    AutoModelForSequenceClassification,
+    AutoTokenizer,
+    BertConfig,
+    BertForSequenceClassification,
+    BertModel,
+    BertTokenizer,
+    PreTrainedModel,
+    get_linear_schedule_with_warmup,
+)
+
+
+class InputExample(object):
+    def __init__(self, guid, text_a, text_b=None, label=None):
+        self.guid = guid
+        self.text_a = text_a
+        self.text_b = text_b
+        self.label = label
+
+
+class InputFeatures(object):
+    def __init__(self, input_ids, input_mask, segment_ids, label_id):
+        self.input_ids = input_ids
+        self.input_mask = input_mask
+        self.segment_ids = segment_ids
+        self.label_id = label_id
+
+
+class DataProcessor(object):
+    """Base class for data converters for sequence classification data sets."""
+
+    def get_train_examples(self, data_dir):
+        """Gets a collection of `InputExample`s for the train set."""
+        raise NotImplementedError()
+
+    def get_dev_examples(self, data_dir):
+        """Gets a collection of `InputExample`s for the dev set."""
+        raise NotImplementedError()
+
+    def get_labels(self, iso_labels):
+        """Gets the list of labels for this data set."""
+        raise NotImplementedError()
+
+    @classmethod
+    def _read_tsv(cls, input_file, quotechar=None):
+        """Reads a tab separated value file."""
+        with open(input_file, "r", encoding="utf-8") as f:
+            reader = csv.reader(f, delimiter="\t", quotechar=quotechar)
+            lines = []
+            for line in reader:
+                if sys.version_info[0] == 2:
+                    line = list(np.unicode(cell, "utf-8") for cell in line)
+                lines.append(line)
+
+            return lines
+
+
+class TradrProcessor(DataProcessor):
+    """Processor for the TRADRZ data set."""
+
+    def get_train_examples(self, data_dir):
+        """See base class."""
+        print("LOOKING AT {}".format(os.path.join(data_dir, "train.tsv")))
+        return self._create_examples(self._read_tsv(os.path.join(data_dir, "train.tsv")), "train")
+
+    def get_dev_examples(self, data_dir):
+        """See base class."""
+        return self._create_examples(self._read_tsv(os.path.join(data_dir, "dev.tsv")), "dev")
+
+    def get_test_examples(self, data_dir):
+        """See base class."""
+        return self._create_examples(self._read_tsv(os.path.join(data_dir, "test.tsv")), "test")
+
+    def get_labels(self, iso_labels):
+        if iso_labels:
+            return [
+                "Promise",
+                "AcceptRequest",
+                "Answer",
+                "Confirm",
+                "Agreement",
+                "Retraction",
+                "SetQuestion",
+                "Disagreement",
+                "Communicative Function",
+                "Auto-negative",
+                "TurnAssign",
+                "Inform",
+                "AcceptOffer",
+                "InteractionStructuring",
+                "FeedbackElicitation",
+                "TurnAccept",
+                "SelfError",
+                "Suggestion",
+                "CheckQuestion",
+                "Offer",
+                "ChoiceQuestion",
+                "AcceptSuggestion",
+                "Interaction Structuring",
+                "DeclineOffer",
+                "AddressOffer",
+                "TurnTake",
+                "SelfCorrection",
+                "DeclineRequest",
+                "Question",
+                "Instruct",
+                "Pausing",
+                "PropositionalQuestion",
+                "Disconfirm",
+                "TurnRelease",
+                "Allo-positive",
+                "Thanking",
+                "Auto-positive",
+                "Stalling",
+                "Opening",
+                "AddressRequest",
+                "Feedback Elicitation",
+                "Request",
+            ]
+        else:
+            return [
+                "Kontakt_Anfrage",
+                "Kontakt_Bestaetigung",
+                "Einsatzbefehl",
+                "Information_geben",
+                "Information_nachfragen",
+                "Zusage",
+                "Absage",
+                "Sonstiges",
+            ]
+
+    def _create_examples(self, lines, set_type):
+        """Creates examples for the training and dev sets."""
+        examples = []
+        prev_turn = ""
+        for (i, line) in enumerate(lines):
+            if i == 0:
+                continue
+            guid = "%s-%s" % (set_type, i)
+            text_b = line[1]
+            if args.mode == "only":
+                text_a = None  # single-sentence training
+            elif args.mode == "speaker":
+                text_a = line[0]  # speaker + sentence
+            elif args.mode == "prev":
+                text_a = prev_turn  # prev sentence + sentence
+            else:
+                raise Exception(
+                    f"Unknown mode {args.mode}! Can be one of the following: only, speaker, prev"
+                )
+            label = line[2]
+            prev_turn = text_b
+            examples.append(InputExample(guid=guid, text_a=text_a, text_b=text_b, label=label))
+
+        return examples
+
+
+def convert_examples_to_features(examples, label_list, max_seq_length, tokenizer):
+    """Loads a data file into a list of `InputBatch`s."""
+
+    label_map = {label: i for i, label in enumerate(label_list)}
+
+    features = []
+    for (ex_index, example) in enumerate(examples):
+        tokens_b = tokenizer.tokenize(example.text_b)
+        tokens_a = None
+        if example.text_a:
+            tokens_a = tokenizer.tokenize(example.text_a)
+            # Modifies `tokens_a` and `tokens_b` in place so that the total
+            # length is less than the specified length.
+            # Account for [CLS], [SEP], [SEP] with "- 3"
+            _truncate_seq_pair(tokens_a, tokens_b, max_seq_length - 3)
+        else:
+            # Account for [CLS] and [SEP] with "- 2"
+            _truncate_seq_pair([], tokens_b, max_seq_length - 2)
+
+        sent = 0
+        tokens = ["[CLS]"]
+        segment_ids = [sent]
+        if tokens_a:
+            tokens += tokens_a + ["[SEP]"]
+            segment_ids = [sent] * len(tokens)
+            sent += 1
+
+        tokens += tokens_b + ["[SEP]"]
+        segment_ids += [sent] * (len(tokens_b) + 1)
+
+        input_ids = tokenizer.convert_tokens_to_ids(tokens)
+
+        # The mask has 1 for real tokens and 0 for padding tokens. Only real
+        # tokens are attended to.
+        input_mask = [1] * len(input_ids)
+
+        # Zero-pad up to the sequence length.
+        padding = [0] * (max_seq_length - len(input_ids))
+        input_ids += padding
+        input_mask += padding
+        segment_ids += padding
+
+        assert len(input_ids) == max_seq_length
+        assert len(input_mask) == max_seq_length
+        assert len(segment_ids) == max_seq_length
+
+        label_id = label_map[example.label]
+
+        if ex_index < 0:
+            print("*** Example ***")
+            print("guid: %s" % example.guid)
+            print("tokens: %s" % " ".join([str(x) for x in tokens]))
+            print("input_ids: %s" % " ".join([str(x) for x in input_ids]))
+            print("input_mask: %s" % " ".join([str(x) for x in input_mask]))
+            print("segment_ids: %s" % " ".join([str(x) for x in segment_ids]))
+            print("label: %s (id = %d)" % (example.label, label_id))
+
+        features.append(
+            InputFeatures(
+                input_ids=input_ids,
+                input_mask=input_mask,
+                segment_ids=segment_ids,
+                label_id=label_id,
+            )
+        )
+
+    return features
+
+
+def _truncate_seq_pair(tokens_a, tokens_b, max_length):
+    """Truncates a sequence pair in place to the maximum length."""
+    while True:
+        total_length = len(tokens_a) + len(tokens_b)
+        if total_length <= max_length:
+            break
+        if len(tokens_a) > len(tokens_b):
+            tokens_a.pop()
+        else:
+            tokens_b.pop()
+
+
+def simple_accuracy(preds, labels):
+    return (preds == labels).mean()
+
+
+def acc_and_f1(preds, labels):
+    acc = simple_accuracy(preds, labels)
+    f1 = f1_score(y_true=labels, y_pred=preds, average="macro")
+    return {
+        "acc": acc,
+        "f1": f1,
+        "acc_and_f1": (acc + f1) / 2,
+    }
+
+
+def train_model(args):
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print(f"device: {device}")
+
+    if not os.path.exists(args.output_dir):
+        os.makedirs(args.output_dir)
+
+    processor = TradrProcessor()
+
+    label_list = processor.get_labels(args.iso_labels)
+    num_labels = len(label_list)
+
+    tokenizer = AutoTokenizer.from_pretrained(args.bert_model)
+    # BertTokenizer.from_pretrained(bert_model, do_lower_case=do_lower_case)
+
+    train_examples = processor.get_train_examples(args.data_dir)
+    num_train_optimization_steps = (
+        int(1 + len(train_examples) / args.train_batch_size) * args.num_train_epochs
+    )
+
+    # Prepare model
+    model = AutoModelForSequenceClassification.from_pretrained(
+        args.bert_model, num_labels=num_labels
+    )
+    model = model.to(device)
+
+    # Prepare optimizer
+    param_optimizer = list(model.named_parameters())
+    no_decay = ["bias", "LayerNorm.weight"]
+    optimizer_grouped_parameters = [
+        {
+            "params": [p for n, p in param_optimizer if not any(nod in n for nod in no_decay)],
+            "weight_decay": 0.01,
+        },
+        {
+            "params": [p for n, p in param_optimizer if any(nod in n for nod in no_decay)],
+            "weight_decay": 0.0,
+        },
+    ]
+
+    optimizer = AdamW(optimizer_grouped_parameters, lr=args.learning_rate)
+    scheduler = get_linear_schedule_with_warmup(
+        optimizer,
+        num_warmup_steps=args.warmup_steps,
+        num_training_steps=num_train_optimization_steps,
+    )
+
+    global_step = 0
+
+    train_features = convert_examples_to_features(
+        train_examples, label_list, args.max_seq_length, tokenizer
+    )
+
+    print(f"Num examples = {len(train_examples)}")
+    print(f"Batch size = {args.train_batch_size}")
+    print(f"Num steps = {num_train_optimization_steps}")
+
+    all_input_ids = torch.tensor([f.input_ids for f in train_features], dtype=torch.long)
+    all_input_mask = torch.tensor([f.input_mask for f in train_features], dtype=torch.long)
+    all_segment_ids = torch.tensor([f.segment_ids for f in train_features], dtype=torch.long)
+    all_label_ids = torch.tensor([f.label_id for f in train_features], dtype=torch.long)
+
+    train_data = TensorDataset(all_input_ids, all_input_mask, all_segment_ids, all_label_ids)
+    train_sampler = RandomSampler(train_data)
+    train_dataloader = DataLoader(
+        train_data, sampler=train_sampler, batch_size=args.train_batch_size
+    )
+
+    evdata = get_eval_data(
+        processor,
+        tokenizer,
+        processor.get_dev_examples(args.data_dir),
+        args.max_seq_length,
+        args.iso_labels,
+    )
+    loss_fct = CrossEntropyLoss()
+
+    model.train()
+    epoch = 0
+    for _ in range(args.num_train_epochs):
+        tr_loss = 0
+        nb_tr_examples, nb_tr_steps = 0, 0
+        for step, batch in enumerate(tqdm(train_dataloader, desc="Iteration")):
+            batch = tuple(t.to(device) for t in batch)
+            input_ids, input_mask, segment_ids, label_ids = batch
+
+            logits = model(input_ids, segment_ids, input_mask)
+            logits = logits[0]
+
+            loss = loss_fct(logits.view(-1, num_labels), label_ids.view(-1))
+            loss.backward()
+
+            tr_loss += loss.item()
+            nb_tr_examples += input_ids.size(0)
+            nb_tr_steps += 1
+
+            optimizer.step()
+            scheduler.step()
+            model.zero_grad()
+            global_step += 1
+
+        out_dir = args.output_dir + "/" + str(epoch)
+        if not os.path.exists(out_dir):
+            os.makedirs(out_dir)
+        print(
+            "Epoch {} Training loss total {} per example {} ".format(
+                epoch, tr_loss, tr_loss / nb_tr_examples
+            )
+        )
+        model.train()
+        eval_model(
+            device,
+            tokenizer,
+            model,
+            args.mode,
+            evdata,
+            out_dir,
+            args.iso_labels,
+            args.max_seq_length,
+        )
+
+        print(f"Saving model checkpoint to {out_dir}")
+        model_to_save = model.module if hasattr(model, "module") else model
+        model_to_save.save_pretrained(out_dir)
+        tokenizer.save_pretrained(out_dir)
+        epoch += 1
+    return model
+
+
+def get_eval_data(processor, tokenizer, eval_examples, max_seq_length, iso_labels):
+    label_list = processor.get_labels(iso_labels)
+    num_labels = len(label_list)
+
+    eval_features = convert_examples_to_features(
+        eval_examples, label_list, max_seq_length, tokenizer
+    )
+
+    print("  Num examples = {}".format(len(eval_examples)))
+
+    all_input_ids = torch.tensor([f.input_ids for f in eval_features], dtype=torch.long)
+    all_input_mask = torch.tensor([f.input_mask for f in eval_features], dtype=torch.long)
+    all_segment_ids = torch.tensor([f.segment_ids for f in eval_features], dtype=torch.long)
+    all_label_ids = torch.tensor([f.label_id for f in eval_features], dtype=torch.long)
+
+    eval_data = TensorDataset(all_input_ids, all_input_mask, all_segment_ids, all_label_ids)
+    return eval_data, num_labels, all_label_ids
+
+
+def load_and_eval_model(args):
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print(f"device: {device}")
+
+    tokenizer = AutoTokenizer.from_pretrained(args.bert_model)
+    processor = TradrProcessor()
+
+    label_list = processor.get_labels(args.iso_labels)
+    num_labels = len(label_list)
+
+    ev_data = get_eval_data(
+        processor,
+        tokenizer,
+        processor.get_test_examples(args.data_dir),
+        args.max_seq_length,
+        args.iso_labels,
+    )
+
+    model = AutoModelForSequenceClassification.from_pretrained(
+        args.output_dir, num_labels=num_labels
+    )
+    model = model.to(device)
+    eval_model(
+        device,
+        tokenizer,
+        model,
+        args.mode,
+        ev_data,
+        args.output_dir,
+        args.iso_labels,
+        eval_batch_size=args.eval_batch_size,
+        max_seq_length=args.max_seq_length,
+        what="test",
+    )
+
+
+def eval_model(
+    device,
+    tokenizer,
+    model,
+    mode,
+    evdat,
+    output_dir,
+    iso_labels,
+    max_seq_length=128,
+    eval_batch_size=8,
+    what="eval",
+    verbose=False,
+):
+    eval_data = evdat[0]
+    num_labels = evdat[1]
+    all_label_ids = evdat[2]
+
+    label_map = {label: i for i, label in enumerate(TradrProcessor().get_labels(iso_labels))}
+    reversed_label_map = {v: k for k, v in label_map.items()}
+
+    eval_sampler = SequentialSampler(eval_data)
+    eval_dataloader = DataLoader(eval_data, sampler=eval_sampler, batch_size=eval_batch_size)
+    print("  Batch size = {}".format(eval_batch_size))
+
+    model.eval()
+
+    eval_loss = 0
+    nb_eval_steps = 0
+    preds = []
+    prev_labels = ["None"] * eval_batch_size
+    label_distribution = dict()
+    total_turns = 0
+
+    for input_ids, input_mask, segment_ids, label_ids in tqdm(eval_dataloader, desc="Evaluating"):
+        input_ids = input_ids.to(device)
+        input_mask = input_mask.to(device)
+        segment_ids = segment_ids.to(device)
+        label_ids = label_ids.to(device)
+
+        with torch.no_grad():
+            logits = model(input_ids, segment_ids, input_mask)
+        logits = logits[0]
+
+        # create eval loss and other metric required by the task
+        loss_fct = CrossEntropyLoss()
+        tmp_eval_loss = loss_fct(logits.view(-1, num_labels), label_ids.view(-1))
+        eval_loss += tmp_eval_loss.mean().item()
+
+        nb_eval_steps += 1
+        if len(preds) == 0:
+            preds.append(logits.detach().cpu().numpy())
+        else:
+            preds[0] = np.append(preds[0], logits.detach().cpu().numpy(), axis=0)
+
+        predicted = np.argmax(logits.detach().cpu().numpy(), axis=1)
+        prev_labels = [reversed_label_map[p] for p in predicted]
+
+        for i in range(len(input_ids)):
+            tokens = tokenizer.convert_ids_to_tokens(input_ids[i][: sum(input_mask[i])])
+            assigned = reversed_label_map[predicted[i]]
+            true_label = reversed_label_map[label_ids[i].item()]
+            total_turns += 1
+            if true_label != assigned and verbose:
+                print(tokens)
+                print("Assigned:", assigned)
+                print("True:", true_label)
+                print()
+
+            if assigned not in label_distribution:
+                label_distribution[assigned] = {"total": 0, "matched": 0}
+            if true_label not in label_distribution:
+                label_distribution[true_label] = {"total": 0, "matched": 0}
+            label_distribution[true_label]["total"] += 1
+            if true_label == assigned:
+                label_distribution[true_label]["matched"] += 1
+
+    print("Label distribution and accuracy per label")
+    all_labels = sum([label_distribution[lbl]["total"] for lbl in label_distribution])
+    for lbl in label_distribution:
+        acc_score = label_distribution[lbl]["matched"] / max(1, label_distribution[lbl]["total"])
+        lbl_proportion = label_distribution[lbl]["total"] / max(1, all_labels)
+        print(
+            lbl,
+            label_distribution[lbl],
+            "proportion:",
+            round(lbl_proportion, 3),
+            "acc:",
+            round(acc_score, 3),
+        )
+    print("Total turns:", total_turns)
+
+    eval_loss = eval_loss / nb_eval_steps
+    preds = preds[0]
+    preds = np.argmax(preds, axis=1)
+
+    result = acc_and_f1(preds, all_label_ids.numpy())
+
+    result["eval_loss"] = eval_loss
+
+    output_eval_file = os.path.join(output_dir, what + "_results.txt")
+    with open(output_eval_file, "w") as writer:
+        print("***** Eval results *****")
+        for key in sorted(result.keys()):
+            print(f"  {key} = {result[key]}")
+            writer.write(f"{key} = {result[key]}\n")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Training or evaluation parameters.")
+    parser.add_argument("--data_dir", type=str)
+    parser.add_argument("--mode", type=str)
+    parser.add_argument("--iso_labels", type=bool, default=False)
+    parser.add_argument("--evaluation", type=bool, default=False)
+    parser.add_argument("--output_dir", type=str, default="outputs")
+    parser.add_argument("--bert_model", type=str, default="dbmdz/bert-base-german-cased")
+    parser.add_argument("--max_seq_length", type=int, default=128)
+    parser.add_argument("--do_lower_case", type=bool, default=False)
+    parser.add_argument("--train_batch_size", type=int, default=32)
+    parser.add_argument("--eval_batch_size", type=int, default=32)
+    parser.add_argument("--learning_rate", type=float, default=1e-5)
+    parser.add_argument("--num_train_epochs", type=int, default=10)
+    parser.add_argument("--warmup_steps", type=int, default=0)
+
+    args = parser.parse_args()
+    if args.evaluation:
+        # evaluate saved model
+        print("Evaluating...")
+        load_and_eval_model(args)
+    else:
+        # train a new model
+        print("Training...")
+        print(args.iso_labels)
+        model = train_model(args)


### PR DESCRIPTION
**Fine-grained ISO-based annotations:**
$ python3 finetune_tradr.py --data_dir=data_iso --mode=speaker --iso_labels=True
$ python3 finetune_tradr.py --evaluation=True --data_dir=data_iso --mode=speaker --output_dir=outputs/8 --iso_labels=True

**Coarse-grained Einsatzbefehl-based annotations:**
$ python3 finetune_tradr.py --data_dir=data_einsatzbefehl --mode=speaker
$ python3 finetune_tradr.py --evaluation=True --data_dir=data_einsatzbefehl --mode=speaker --output_dir=outputs/8

`--evaluation` specifies whether to run this code in the evaluation mode, by default it is set to False, so it does the training
`--data_dir` specifies the input directory with train/val/test data (e.g. data_iso)
`--output_dir` where to store the trained models/checkpoints
`--mode` can be speaker (uses speaker information), prev (including previous turn) or only (only the current turn)
`--iso_labels` specifies whether to use the ISO labels